### PR TITLE
fix: remove link do admin no rodape

### DIFF
--- a/front-vassouras/src/components/Footer.jsx
+++ b/front-vassouras/src/components/Footer.jsx
@@ -1,11 +1,7 @@
 import { Link } from 'react-router-dom';
 import { MapPin, Mail, Phone } from 'lucide-react';
-import { API_BASE_URL } from '../services/api.js';
 
 function Footer() {
-  // O admin do Django fica na raiz do backend, fora do /api/.
-  const adminUrl = `${API_BASE_URL}/admin`;
-
   return (
     <footer className='bg-gray-100 text-white py-6 mt-5 justify-center items-center w-full border-t shadow-lg'>
       <div className='container grid grid-cols-1 md:grid-cols-3 gap-4 mx-auto text-center'>


### PR DESCRIPTION
## Contexto

O rodapé tinha um link **Acesso Restrito** apontando para o Django admin, visível em todas as páginas públicas do site.

## Por que remover

- **Nenhum valor para o usuário final.** Quem compra vassoura nunca clica nesse link. Quem usa o admin é o cliente (uma ou duas pessoas), que pode salvar a URL nos favoritos.
- **Indexação pelo Google.** O site inteiro existe para ranquear no Google Ads e na busca orgânica. Uma página de login aparecendo nos resultados da busca pelo nome da empresa não ajuda.
- **Componente errado.** Era um `<Link>` do react-router-dom apontando para uma URL absoluta de outro domínio. `Link` é para rotas internas — dependendo da versão do router isso funciona por acidente ou gera navegação quebrada.

## O que muda

- Remove o `<li>` do link no rodapé
- Remove `const adminUrl` e o import de `API_BASE_URL`, que só existiam para esse link

Nada mais no rodapé é afetado: mapa, links de navegação e bloco de contatos seguem iguais.

## Relacionado

O PR do backend (`feat/protege-admin`) move o admin para um caminho definido por `ADMIN_URL` e adiciona bloqueio de tentativas de login. Remover este link não era a proteção — era só limpeza. A proteção real está lá.

## Anotação para a visita ao cliente

`Footer.jsx` ainda tem dados de exemplo que precisam ser confirmados:

- linha ~71: `Rua São Miguel, 1234 - Afogados, Recife - PE, 50850-000`
- linha ~76: `(81) 9999-9999`
- linha ~80: `contato@vassouraspernambucanas.com.br` (caixa de e-mail ainda não existe)
