### PR TITLE
feat: estado de erro no detalhe do produto e tag de conversao do Ads

### DIFF
--- a/front-vassouras/package-lock.json
+++ b/front-vassouras/package-lock.json
@@ -21,6 +21,7 @@
         "@eslint/js": "^9.39.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.2.2",
@@ -2081,6 +2082,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/front-vassouras/package.json
+++ b/front-vassouras/package.json
@@ -24,6 +24,7 @@
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.2.2",

--- a/front-vassouras/src/components/BotaoWhatsapp.jsx
+++ b/front-vassouras/src/components/BotaoWhatsapp.jsx
@@ -1,10 +1,12 @@
 import gerarLinkWhatsapp from '../utils/GeraLinkWhatsapp';
 import { MessageCircle, ArrowRight } from 'lucide-react';
+import { registrarConversaoWhatsapp } from '../services/ads';
 
 const BotaoWhatsapp = ({ produto }) => {
   return (
     <a
       href={gerarLinkWhatsapp(produto)}
+      onClick={registrarConversaoWhatsapp}
       target='_blank'
       rel='noopener noreferrer'
       className='group w-full flex items-center justify-center lg:justify-between p-6 bg-[#25D366] hover:bg-[#1ebd5b] text-white rounded-2xl transition-all shadow-md hover:shadow-lg'

--- a/front-vassouras/src/main.jsx
+++ b/front-vassouras/src/main.jsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { iniciarGtag } from './services/ads.js'
+
+iniciarGtag()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/front-vassouras/src/pages/ProdutoDetalhe.jsx
+++ b/front-vassouras/src/pages/ProdutoDetalhe.jsx
@@ -8,6 +8,8 @@ import { API_BASE_URL } from '../services/api.js';
 function ProdutoDetalhe() {
   const { id } = useParams();
   const [produto, setProduto] = useState(null);
+  const [erro, setErro] = useState(null);
+  const [tentativa, setTentativa] = useState(0);
   const [relacionados, setRelacionados] = useState([]);
   const [loadingRelacionados, setLoadingRelacionados] = useState(false);
 
@@ -15,6 +17,7 @@ function ProdutoDetalhe() {
     const controller = new AbortController();
 
     setProduto(null);
+    setErro(null);
     window.scrollTo(0, 0);
 
     async function fetchProduto() {
@@ -22,6 +25,10 @@ function ProdutoDetalhe() {
         const response = await fetch(`${API_BASE_URL}/api/produtos/${id}/`, {
           signal: controller.signal,
         });
+        if (response.status === 404) {
+          setErro('nao-encontrado');
+          return;
+        }
         if (!response.ok)
           throw new Error(`HTTP error! status: ${response.status}`);
         const data = await response.json();
@@ -29,6 +36,7 @@ function ProdutoDetalhe() {
       } catch (error) {
         if (error.name !== 'AbortError') {
           console.error('Erro ao buscar detalhes do produto:', error);
+          setErro('falha');
         }
       }
     }
@@ -36,7 +44,7 @@ function ProdutoDetalhe() {
     fetchProduto();
 
     return () => controller.abort();
-  }, [id]);
+  }, [id, tentativa]);
 
   useEffect(() => {
     if (!produto?.categoria) return;
@@ -78,6 +86,36 @@ function ProdutoDetalhe() {
       currency: 'BRL',
     }).format(valor);
   };
+
+  if (erro) {
+    const naoEncontrado = erro === 'nao-encontrado';
+
+    return (
+      <div className='p-10 text-center flex flex-col items-center gap-4'>
+        <h2 className='text-2xl font-bold text-gray-900'>
+          {naoEncontrado
+            ? 'Produto não encontrado'
+            : 'Não foi possível carregar o produto'}
+        </h2>
+        <p className='text-gray-600'>
+          {naoEncontrado
+            ? 'Este produto pode ter saído do catálogo.'
+            : 'Verifique sua conexão e tente de novo.'}
+        </p>
+        {!naoEncontrado && (
+          <button
+            onClick={() => setTentativa((numero) => numero + 1)}
+            className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded'
+          >
+            Tentar novamente
+          </button>
+        )}
+        <Link to='/produtos' className='text-blue-600 underline'>
+          Ver todos os produtos
+        </Link>
+      </div>
+    );
+  }
 
   if (!produto) {
     return <div className='p-10 text-center'>Carregando detalhes...</div>;

--- a/front-vassouras/src/pages/ProdutoDetalhe.test.jsx
+++ b/front-vassouras/src/pages/ProdutoDetalhe.test.jsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ProdutoDetalhe from './ProdutoDetalhe';
+
+const PRODUTO = {
+  id: 1,
+  nome: 'Vassoura de Piaçava',
+  descricao: 'Cabo longo, cerdas naturais.',
+  preco: '30.00',
+  imagem: null,
+  categoria: 2,
+};
+
+const resposta = (corpo, status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(corpo),
+  });
+
+function renderizar() {
+  return render(
+    <MemoryRouter initialEntries={['/produto/1']}>
+      <Link to='/produto/2'>ir para o produto 2</Link>
+      <Routes>
+        <Route path='/produto/:id' element={<ProdutoDetalhe />} />
+        <Route path='/produtos' element={<h2>Pagina do catalogo</h2>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ProdutoDetalhe', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => resposta(PRODUTO)));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('deve exibir o produto quando a api responde', async () => {
+    fetch.mockImplementation((url) =>
+      String(url).includes('?categoria=') ? resposta([]) : resposta(PRODUTO)
+    );
+
+    renderizar();
+
+    expect(await screen.findByText('Vassoura de Piaçava')).toBeInTheDocument();
+  });
+
+  it('deve exibir nao encontrado quando a api responde 404', async () => {
+    fetch.mockImplementation(() => resposta({ detail: 'nao encontrado' }, 404));
+
+    renderizar();
+
+    expect(await screen.findByText(/não encontrado/i)).toBeInTheDocument();
+    expect(screen.queryByText(/carregando detalhes/i)).not.toBeInTheDocument();
+  });
+
+  it('deve exibir erro quando a rede falha', async () => {
+    fetch.mockImplementation(() => Promise.reject(new TypeError('falhou')));
+
+    renderizar();
+
+    expect(
+      await screen.findByRole('button', { name: /tentar novamente/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/carregando detalhes/i)).not.toBeInTheDocument();
+  });
+
+  it('deve refazer a busca ao clicar em tentar novamente', async () => {
+    fetch.mockImplementation(() => Promise.reject(new TypeError('falhou')));
+
+    renderizar();
+
+    const botao = await screen.findByRole('button', {
+      name: /tentar novamente/i,
+    });
+
+    fetch.mockImplementation((url) =>
+      String(url).includes('?categoria=') ? resposta([]) : resposta(PRODUTO)
+    );
+    await userEvent.click(botao);
+
+    expect(await screen.findByText('Vassoura de Piaçava')).toBeInTheDocument();
+  });
+
+  it('nao deve manter o erro ao trocar de produto', async () => {
+    fetch.mockImplementation(() => resposta({ detail: 'nao encontrado' }, 404));
+
+    renderizar();
+
+    await screen.findByText(/não encontrado/i);
+
+    fetch.mockImplementation((url) =>
+      String(url).includes('?categoria=') ? resposta([]) : resposta(PRODUTO)
+    );
+    await userEvent.click(screen.getByText('ir para o produto 2'));
+
+    expect(await screen.findByText('Vassoura de Piaçava')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText(/não encontrado/i)).not.toBeInTheDocument()
+    );
+  });
+});

--- a/front-vassouras/src/services/ads.js
+++ b/front-vassouras/src/services/ads.js
@@ -1,0 +1,26 @@
+export function iniciarGtag() {
+  const adsId = import.meta.env.VITE_GADS_ID;
+  if (!adsId) return;
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${adsId}`;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  // Precisa ser a funcao de fila (e `function`, nao arrow, por causa do
+  // `arguments`): sem ela, evento disparado antes de o script carregar some.
+  window.gtag = function () {
+    window.dataLayer.push(arguments);
+  };
+  window.gtag('js', new Date());
+  window.gtag('config', adsId);
+}
+
+export function registrarConversaoWhatsapp() {
+  const adsId = import.meta.env.VITE_GADS_ID;
+  const label = import.meta.env.VITE_GADS_CONVERSION_LABEL;
+  if (!adsId || !label) return;
+
+  window.gtag('event', 'conversion', { send_to: `${adsId}/${label}` });
+}

--- a/front-vassouras/src/services/ads.test.js
+++ b/front-vassouras/src/services/ads.test.js
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { iniciarGtag, registrarConversaoWhatsapp } from './ads';
+
+const scriptsDoGtag = () =>
+  document.head.querySelectorAll('script[src*="googletagmanager"]');
+
+describe('ads', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    delete window.gtag;
+    delete window.dataLayer;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('nao deve injetar o script sem VITE_GADS_ID', () => {
+    vi.stubEnv('VITE_GADS_ID', '');
+
+    iniciarGtag();
+
+    expect(scriptsDoGtag()).toHaveLength(0);
+    expect(window.gtag).toBeUndefined();
+  });
+
+  it('deve injetar o script quando ha id', () => {
+    vi.stubEnv('VITE_GADS_ID', 'AW-123');
+
+    iniciarGtag();
+
+    const scripts = scriptsDoGtag();
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0].src).toContain('AW-123');
+  });
+
+  it('deve enfileirar js e config no dataLayer', () => {
+    vi.stubEnv('VITE_GADS_ID', 'AW-123');
+
+    iniciarGtag();
+
+    expect(window.dataLayer).toHaveLength(2);
+    expect(Array.from(window.dataLayer[1])).toEqual(['config', 'AW-123']);
+  });
+
+  it('nao deve disparar conversao sem id', () => {
+    vi.stubEnv('VITE_GADS_ID', '');
+    vi.stubEnv('VITE_GADS_CONVERSION_LABEL', 'abc123');
+    window.gtag = vi.fn();
+
+    registrarConversaoWhatsapp();
+
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+
+  it('nao deve disparar conversao sem label', () => {
+    vi.stubEnv('VITE_GADS_ID', 'AW-123');
+    vi.stubEnv('VITE_GADS_CONVERSION_LABEL', '');
+    window.gtag = vi.fn();
+
+    registrarConversaoWhatsapp();
+
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+
+  it('deve disparar conversao com send_to correto', () => {
+    vi.stubEnv('VITE_GADS_ID', 'AW-123');
+    vi.stubEnv('VITE_GADS_CONVERSION_LABEL', 'abc123');
+    window.gtag = vi.fn();
+
+    registrarConversaoWhatsapp();
+
+    expect(window.gtag).toHaveBeenCalledWith('event', 'conversion', {
+      send_to: 'AW-123/abc123',
+    });
+  });
+});


### PR DESCRIPTION
Fecha os itens **#31** e **#29** do handoff.

> ⚠️ **Empilhado sobre o #19** (o hotfix do rodapé), porque depende da infra de
> teste de componente que entra lá. A base deste PR é
> `fix/rodape-referencia-quebrada`, então o diff mostra só as mudanças próprias.
> Quando o #19 for mergeado, o GitHub reaponta este PR para a `main` sozinho.
> **Mergear o #19 primeiro.**

## #31 — página de produto travada em "Carregando..."

O defeito era uma variável carregando dois significados: `produto === null`
queria dizer "carregando" **e** "falhou". O `catch` só fazia `console.error`,
então qualquer falha de fetch deixava a página em "Carregando detalhes..." para
sempre. Um anúncio apontando para um produto removido virava spinner infinito
como landing page.

Segue o mesmo padrão que o `Catalogo.jsx` já usava (estados separados), em vez de
inventar outro. E distingue os dois casos, porque a ação certa é diferente:

- **404** → "Produto não encontrado" + link para o catálogo. É o caso que salva
  dinheiro: devolve o clique pago em vez de queimá-lo.
- **falha de rede** → mensagem + "Tentar novamente". O público é mobile em rede
  instável.

O `setErro(null)` no início do efeito é o que impede o erro de grudar ao navegar
entre produtos — tem teste só para isso.

## #29 — tag de conversão do Google Ads

Novo `src/services/ads.js`, ligado por `VITE_GADS_ID`. **Sem a variável, nada
acontece:** nenhum script de terceiro, nenhum cookie, zero impacto no Lighthouse.
Por isso já pode ir para produção antes de a conta do Ads existir (dúvida aberta
#1 do handoff) — depois é só configurar as duas variáveis, sem tocar em código.

Detalhes que decidem se funciona:

- `window.gtag` é a função de fila (`dataLayer.push(arguments)`) e é `function`,
  não arrow, por causa do `arguments`. Sem isso, evento disparado antes de o
  script carregar some.
- O botão já é `target="_blank"`, então a aba atual sobrevive ao clique e o
  evento tem tempo de sair — não precisa de `sendBeacon` nem `event_callback`
  aqui. (A ressalva da seção 8 do handoff era para o POST da Fase 3, em
  navegação na mesma aba.)
- **Setar `VITE_GADS_ID` só no ambiente Production da Vercel.** No escopo do
  projeto inteiro, cada preview e cada `npm run dev` manda conversão falsa e
  envenena o Smart Bidding.
- O ID **não é segredo** (aparece no HTML de qualquer site que usa Ads). A
  variável é para adiar e separar ambientes, não é medida de segurança.

O ID é lido **dentro** das funções, não em `const` de módulo. `import.meta.env`
em constante de topo é avaliado uma vez no import, e aí `vi.stubEnv` não teria
efeito sem `vi.resetModules()` e `import()` dinâmico em cada teste. Custo em
produção: zero. Foi o teste melhorando o desenho.

## Testes

11 novos, escritos antes das correções.

- **antes:** 4 falhas em `ProdutoDetalhe` + `ads.test.js` sem conseguir resolver
  o import
- **depois:** 17 testes passando, `eslint` limpo, build ok (+0,8 kB no bundle)

Fora de escopo, registrado: carregar o gtag seta cookie e a LGPD pede banner de
consentimento. Decisão do cliente, não bloqueia o go-live.