### PR TITLE
feat: estado de erro no ProdutoDetalhe e tag de conversao do Ads (reabre o PR #20, que nunca chegou na main)

### DIFF
--- a/front-vassouras/package-lock.json
+++ b/front-vassouras/package-lock.json
@@ -21,6 +21,7 @@
         "@eslint/js": "^9.39.1",
         "@testing-library/jest-dom": "^7.0.0",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.2.2",
@@ -2081,6 +2082,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/front-vassouras/package.json
+++ b/front-vassouras/package.json
@@ -24,6 +24,7 @@
     "@eslint/js": "^9.39.1",
     "@testing-library/jest-dom": "^7.0.0",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.2.2",

--- a/front-vassouras/src/components/BotaoWhatsapp.jsx
+++ b/front-vassouras/src/components/BotaoWhatsapp.jsx
@@ -1,10 +1,12 @@
 import gerarLinkWhatsapp from '../utils/GeraLinkWhatsapp';
 import { MessageCircle, ArrowRight } from 'lucide-react';
+import { registrarConversaoWhatsapp } from '../services/ads';
 
 const BotaoWhatsapp = ({ produto }) => {
   return (
     <a
       href={gerarLinkWhatsapp(produto)}
+      onClick={registrarConversaoWhatsapp}
       target='_blank'
       rel='noopener noreferrer'
       className='group w-full flex items-center justify-center lg:justify-between p-6 bg-[#25D366] hover:bg-[#1ebd5b] text-white rounded-2xl transition-all shadow-md hover:shadow-lg'

--- a/front-vassouras/src/main.jsx
+++ b/front-vassouras/src/main.jsx
@@ -2,6 +2,9 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
+import { iniciarGtag } from './services/ads.js'
+
+iniciarGtag()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/front-vassouras/src/pages/ProdutoDetalhe.jsx
+++ b/front-vassouras/src/pages/ProdutoDetalhe.jsx
@@ -8,6 +8,8 @@ import { API_BASE_URL } from '../services/api.js';
 function ProdutoDetalhe() {
   const { id } = useParams();
   const [produto, setProduto] = useState(null);
+  const [erro, setErro] = useState(null);
+  const [tentativa, setTentativa] = useState(0);
   const [relacionados, setRelacionados] = useState([]);
   const [loadingRelacionados, setLoadingRelacionados] = useState(false);
 
@@ -15,6 +17,7 @@ function ProdutoDetalhe() {
     const controller = new AbortController();
 
     setProduto(null);
+    setErro(null);
     window.scrollTo(0, 0);
 
     async function fetchProduto() {
@@ -22,6 +25,10 @@ function ProdutoDetalhe() {
         const response = await fetch(`${API_BASE_URL}/api/produtos/${id}/`, {
           signal: controller.signal,
         });
+        if (response.status === 404) {
+          setErro('nao-encontrado');
+          return;
+        }
         if (!response.ok)
           throw new Error(`HTTP error! status: ${response.status}`);
         const data = await response.json();
@@ -29,6 +36,7 @@ function ProdutoDetalhe() {
       } catch (error) {
         if (error.name !== 'AbortError') {
           console.error('Erro ao buscar detalhes do produto:', error);
+          setErro('falha');
         }
       }
     }
@@ -36,7 +44,7 @@ function ProdutoDetalhe() {
     fetchProduto();
 
     return () => controller.abort();
-  }, [id]);
+  }, [id, tentativa]);
 
   useEffect(() => {
     if (!produto?.categoria) return;
@@ -78,6 +86,36 @@ function ProdutoDetalhe() {
       currency: 'BRL',
     }).format(valor);
   };
+
+  if (erro) {
+    const naoEncontrado = erro === 'nao-encontrado';
+
+    return (
+      <div className='p-10 text-center flex flex-col items-center gap-4'>
+        <h2 className='text-2xl font-bold text-gray-900'>
+          {naoEncontrado
+            ? 'Produto não encontrado'
+            : 'Não foi possível carregar o produto'}
+        </h2>
+        <p className='text-gray-600'>
+          {naoEncontrado
+            ? 'Este produto pode ter saído do catálogo.'
+            : 'Verifique sua conexão e tente de novo.'}
+        </p>
+        {!naoEncontrado && (
+          <button
+            onClick={() => setTentativa((numero) => numero + 1)}
+            className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded'
+          >
+            Tentar novamente
+          </button>
+        )}
+        <Link to='/produtos' className='text-blue-600 underline'>
+          Ver todos os produtos
+        </Link>
+      </div>
+    );
+  }
 
   if (!produto) {
     return <div className='p-10 text-center'>Carregando detalhes...</div>;

--- a/front-vassouras/src/pages/ProdutoDetalhe.test.jsx
+++ b/front-vassouras/src/pages/ProdutoDetalhe.test.jsx
@@ -1,0 +1,108 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ProdutoDetalhe from './ProdutoDetalhe';
+
+const PRODUTO = {
+  id: 1,
+  nome: 'Vassoura de Piaçava',
+  descricao: 'Cabo longo, cerdas naturais.',
+  preco: '30.00',
+  imagem: null,
+  categoria: 2,
+};
+
+const resposta = (corpo, status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(corpo),
+  });
+
+function renderizar() {
+  return render(
+    <MemoryRouter initialEntries={['/produto/1']}>
+      <Link to='/produto/2'>ir para o produto 2</Link>
+      <Routes>
+        <Route path='/produto/:id' element={<ProdutoDetalhe />} />
+        <Route path='/produtos' element={<h2>Pagina do catalogo</h2>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ProdutoDetalhe', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => resposta(PRODUTO)));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('deve exibir o produto quando a api responde', async () => {
+    fetch.mockImplementation((url) =>
+      String(url).includes('?categoria=') ? resposta([]) : resposta(PRODUTO)
+    );
+
+    renderizar();
+
+    expect(await screen.findByText('Vassoura de Piaçava')).toBeInTheDocument();
+  });
+
+  it('deve exibir nao encontrado quando a api responde 404', async () => {
+    fetch.mockImplementation(() => resposta({ detail: 'nao encontrado' }, 404));
+
+    renderizar();
+
+    expect(await screen.findByText(/não encontrado/i)).toBeInTheDocument();
+    expect(screen.queryByText(/carregando detalhes/i)).not.toBeInTheDocument();
+  });
+
+  it('deve exibir erro quando a rede falha', async () => {
+    fetch.mockImplementation(() => Promise.reject(new TypeError('falhou')));
+
+    renderizar();
+
+    expect(
+      await screen.findByRole('button', { name: /tentar novamente/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/carregando detalhes/i)).not.toBeInTheDocument();
+  });
+
+  it('deve refazer a busca ao clicar em tentar novamente', async () => {
+    fetch.mockImplementation(() => Promise.reject(new TypeError('falhou')));
+
+    renderizar();
+
+    const botao = await screen.findByRole('button', {
+      name: /tentar novamente/i,
+    });
+
+    fetch.mockImplementation((url) =>
+      String(url).includes('?categoria=') ? resposta([]) : resposta(PRODUTO)
+    );
+    await userEvent.click(botao);
+
+    expect(await screen.findByText('Vassoura de Piaçava')).toBeInTheDocument();
+  });
+
+  it('nao deve manter o erro ao trocar de produto', async () => {
+    fetch.mockImplementation(() => resposta({ detail: 'nao encontrado' }, 404));
+
+    renderizar();
+
+    await screen.findByText(/não encontrado/i);
+
+    fetch.mockImplementation((url) =>
+      String(url).includes('?categoria=') ? resposta([]) : resposta(PRODUTO)
+    );
+    await userEvent.click(screen.getByText('ir para o produto 2'));
+
+    expect(await screen.findByText('Vassoura de Piaçava')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText(/não encontrado/i)).not.toBeInTheDocument()
+    );
+  });
+});

--- a/front-vassouras/src/services/ads.js
+++ b/front-vassouras/src/services/ads.js
@@ -1,0 +1,26 @@
+export function iniciarGtag() {
+  const adsId = import.meta.env.VITE_GADS_ID;
+  if (!adsId) return;
+
+  const script = document.createElement('script');
+  script.async = true;
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${adsId}`;
+  document.head.appendChild(script);
+
+  window.dataLayer = window.dataLayer || [];
+  // Precisa ser a funcao de fila (e `function`, nao arrow, por causa do
+  // `arguments`): sem ela, evento disparado antes de o script carregar some.
+  window.gtag = function () {
+    window.dataLayer.push(arguments);
+  };
+  window.gtag('js', new Date());
+  window.gtag('config', adsId);
+}
+
+export function registrarConversaoWhatsapp() {
+  const adsId = import.meta.env.VITE_GADS_ID;
+  const label = import.meta.env.VITE_GADS_CONVERSION_LABEL;
+  if (!adsId || !label) return;
+
+  window.gtag('event', 'conversion', { send_to: `${adsId}/${label}` });
+}

--- a/front-vassouras/src/services/ads.test.js
+++ b/front-vassouras/src/services/ads.test.js
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { iniciarGtag, registrarConversaoWhatsapp } from './ads';
+
+const scriptsDoGtag = () =>
+  document.head.querySelectorAll('script[src*="googletagmanager"]');
+
+describe('ads', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    delete window.gtag;
+    delete window.dataLayer;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('nao deve injetar o script sem VITE_GADS_ID', () => {
+    vi.stubEnv('VITE_GADS_ID', '');
+
+    iniciarGtag();
+
+    expect(scriptsDoGtag()).toHaveLength(0);
+    expect(window.gtag).toBeUndefined();
+  });
+
+  it('deve injetar o script quando ha id', () => {
+    vi.stubEnv('VITE_GADS_ID', 'AW-123');
+
+    iniciarGtag();
+
+    const scripts = scriptsDoGtag();
+    expect(scripts).toHaveLength(1);
+    expect(scripts[0].src).toContain('AW-123');
+  });
+
+  it('deve enfileirar js e config no dataLayer', () => {
+    vi.stubEnv('VITE_GADS_ID', 'AW-123');
+
+    iniciarGtag();
+
+    expect(window.dataLayer).toHaveLength(2);
+    expect(Array.from(window.dataLayer[1])).toEqual(['config', 'AW-123']);
+  });
+
+  it('nao deve disparar conversao sem id', () => {
+    vi.stubEnv('VITE_GADS_ID', '');
+    vi.stubEnv('VITE_GADS_CONVERSION_LABEL', 'abc123');
+    window.gtag = vi.fn();
+
+    registrarConversaoWhatsapp();
+
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+
+  it('nao deve disparar conversao sem label', () => {
+    vi.stubEnv('VITE_GADS_ID', 'AW-123');
+    vi.stubEnv('VITE_GADS_CONVERSION_LABEL', '');
+    window.gtag = vi.fn();
+
+    registrarConversaoWhatsapp();
+
+    expect(window.gtag).not.toHaveBeenCalled();
+  });
+
+  it('deve disparar conversao com send_to correto', () => {
+    vi.stubEnv('VITE_GADS_ID', 'AW-123');
+    vi.stubEnv('VITE_GADS_CONVERSION_LABEL', 'abc123');
+    window.gtag = vi.fn();
+
+    registrarConversaoWhatsapp();
+
+    expect(window.gtag).toHaveBeenCalledWith('event', 'conversion', {
+      send_to: 'AW-123/abc123',
+    });
+  });
+});


### PR DESCRIPTION
## Por que este PR existe

O PR #20 aparece como **MERGED** no GitHub, mas o trabalho dele **nunca chegou à `main`**.

Ele foi aberto com base em `fix/rodape-referencia-quebrada` (a branch do PR #19), porque
dependia da infra de teste que entrava lá. A expectativa registrada no handoff era que o
GitHub reapontasse a base para a `main` sozinho depois do merge do #19 — **isso não
aconteceu**, porque o GitHub só reaponta quando a branch base é *deletada* após o merge, e
ela não foi. Resultado: o #20 mergeou para dentro de uma branch sem saída.

Consequência prática: o commit `6381e37` está marcado como entregue em todo painel, mas
**não está em produção**. Na `main` de hoje o `ProdutoDetalhe.jsx` ainda trava em
"Carregando detalhes..." para sempre quando o fetch falha (item #31), e o
`src/services/ads.js` simplesmente não existe (item #29).

## O que entra

- **Item #31** — estado de erro no `ProdutoDetalhe`, com 404 ("Produto não encontrado")
  distinguido de falha de rede, e botão "Tentar novamente".
- **Item #29** — `src/services/ads.js` com `iniciarGtag()` e `registrarConversaoWhatsapp()`,
  ligado em `main.jsx` e no `onClick` do `BotaoWhatsapp`.
- Testes de `ProdutoDetalhe` e de `ads`, e `@testing-library/user-event` como devDependency.

O item #29 continua **bloqueado pré-Ads** depois deste merge: sem `VITE_GADS_ID` e
`VITE_GADS_CONVERSION_LABEL` setadas no ambiente **Production** da Vercel, nada carrega.

## ⚠️ Este PR tem conflito e ele NÃO deve ser resolvido linha a linha

Conflito em **um** arquivo: `src/pages/ProdutoDetalhe.jsx`. Todo o resto automerge.

O conflito é textual, não semântico. O PR #21 (SonarQube/WebStorm) reindentou o arquivo
inteiro de 2 para 4 espaços, mudou `{ x }` para `{x}` e trocou o `fetch` cru por
`buscarJson`. Este PR mexe em outras seis coisas no mesmo arquivo. Git vê os dois blocos
sobrepostos e desiste.

**Como resolver:** ficar com a versão da `main` inteira e reaplicar à mão as seis mudanças
deste PR (estados `erro` e `tentativa`, `setErro(null)` no início do efeito, `setErro` no
catch, `[id, tentativa]` na lista de dependências, e o bloco de render do erro).

🔴 **A armadilha:** este PR detecta o 404 com `response.status === 404` **antes** de ler o
corpo. Na `main` esse trecho não existe mais — quem fala com a rede agora é o `buscarJson`,
que **lança** em resposta não-ok e **não expõe o status**. Reaplicar o bloco como está faz o
teste `deve exibir nao encontrado quando a api responde 404` falhar, porque todo erro vira
"falha" genérica.

Correção junto, em `src/services/api.js`:

```js
if (!response.ok) {
  const erro = new Error(`HTTP error! status: ${response.status}`);
  erro.status = response.status;
  throw erro;
}
```

E no catch do `ProdutoDetalhe`: `setErro(error.status === 404 ? 'nao-encontrado' : 'falha')`.

## Depois de resolver

- `npm install` (entra o `@testing-library/user-event`) — e **regerar o `package-lock.json`**
  em vez de confiar no automerge dele.
- `npm run lint` e `npm test` — os testes de 404 são o checador de que a resolução ficou certa.
- Depois do deploy: abrir `/produto/999999` e conferir que aparece "Produto não encontrado",
  não spinner eterno. **Olhar o console**, não só o status HTTP.
