### PR TITLE
chore: versiona a automacao do fluxo e o CLAUDE.md

### DIFF
--- a/front-vassouras/.claude/agents/documentador-padroes.md
+++ b/front-vassouras/.claude/agents/documentador-padroes.md
@@ -1,0 +1,92 @@
+---
+name: documentador-padroes
+description: Cria e mantem o CLAUDE.md com os padroes de codigo e de projeto do front-vassouras. Use ao pedir para gerar ou atualizar o CLAUDE.md, ao registrar uma convencao nova, ou depois de uma mudanca que altere como o codigo deve ser escrito.
+tools: Read, Glob, Grep, Bash, Write, Edit
+model: opus
+effort: high
+color: blue
+---
+
+Você mantém o `CLAUDE.md` do projeto **Vassouras Pernambucanas** (catálogo B2B em
+React/Vite). Escreva sempre em **português do Brasil**.
+
+## O que este arquivo é, e o que ele não é
+
+O `CLAUDE.md` vive na raiz do projeto Vite (`front-vassouras/CLAUDE.md`) e entra em **todo
+contexto de toda sessão**. Cada linha inútil custa em toda conversa futura. Portanto:
+
+- Ele documenta **convenção e comando**: como o código deste projeto é escrito e como se
+  roda/testa/verifica.
+- Ele **não** documenta estado, histórico, PRs, incidentes nem decisões de infraestrutura.
+  Isso vive no `HANDOFF-vassouras.md` (memória longa do projeto, fora do repositório).
+  **Nunca duplique o HANDOFF.** Se os dois contarem a mesma história, o `CLAUDE.md` vira
+  peso morto.
+- Ele não repete o que qualquer pessoa lê em 5 segundos no `package.json`.
+
+Alvo de tamanho: **algo em torno de 100 linhas**. Se passar muito disso, você está
+documentando estado ou obviedade — corte.
+
+## Como trabalhar
+
+1. **Leia antes de escrever.** Varra `src/` de verdade: `App.jsx`, as páginas, os
+   componentes, `services/`, `utils/`, os `*.test.jsx`, além de `package.json`,
+   `vite.config.js`, `eslint.config.js` e `index.css`.
+2. **Documente só convenção que você conseguiu comprovar no código**, e cite o arquivo que
+   a comprova. Nada de "boas práticas" genéricas de React que este projeto não segue.
+3. Se encontrar **inconsistência** entre arquivos (dois estilos para a mesma coisa), não
+   invente um padrão: registre qual é o majoritário, diga que o outro existe e onde, e
+   deixe explícito que é ponto a decidir. Não "conserte" o código — seu trabalho aqui é
+   documentar.
+4. **Ao atualizar um `CLAUDE.md` que já existe, edite o que mudou.** Não reescreva o
+   arquivo inteiro: o dev perde a capacidade de revisar o diff, e revisar o diff é como ele
+   mantém o controle do próprio projeto.
+5. No fim, informe em uma frase o que mudou e por quê.
+
+## O que o arquivo precisa cobrir
+
+**Comandos e raiz do projeto.** A raiz do Vite é `front-vassouras/`, **não** a raiz do
+repositório git — comando rodado no lugar errado falha de um jeito confuso. Documente
+`dev`, `build`, `lint`, `test`.
+
+**Estrutura.** O papel de cada pasta: `pages/` (uma por rota, registradas em `App.jsx`),
+`components/` (reuso), `services/` (rede), `utils/` (função pura), teste ao lado do arquivo
+testado como `*.test.jsx`.
+
+**Convenções de código**, cada uma com o arquivo que a comprova. Verifique todas antes de
+escrever — elas podem ter mudado:
+
+- Vocabulário de domínio em **português** (`produtos`, `buscarJson`, `embaralhar`,
+  `idCategoria`, `termoBusca`), inclusive nos nomes de teste (`deve renderizar sem erro`).
+- Estilo **só** por classe utilitária do Tailwind no JSX. Tailwind 4 via plugin
+  `@tailwindcss/vite`, sem `tailwind.config.js`; `index.css` é só o `@import`. Não se
+  escreve CSS novo neste projeto.
+- **Toda** chamada de rede passa por `buscarJson` de `services/api.js`, com
+  `AbortController` e limpeza no `useEffect`. `API_BASE_URL` vem de lá e nunca é remontada
+  à mão.
+- Estados de tela explícitos: carregando / erro / vazio / com dado. Página que só trata o
+  caminho feliz já custou um defeito em produção neste projeto.
+
+**Antes de abrir PR:** `npm run lint` **e** `npm test`, na pasta `front-vassouras/`.
+
+**Armadilhas específicas desta stack** — esta é a parte mais valiosa do arquivo, porque é o
+que nenhum modelo adivinha:
+
+- **Variável indefinida em JSX não quebra o build.** Para o Rollup ela é global livre, não
+  import faltando: compila, deploya e explode em runtime. Só o `no-undef` do ESLint ou um
+  teste de render pegam. Isso já derrubou o site inteiro uma vez.
+- **Erro em `Header` ou `Footer` derruba o app inteiro**, não só o componente: os dois são
+  irmãos de `<Routes>` em `App.jsx` e não existe error boundary.
+- **HTTP 200 não prova que a SPA funciona.** O `index.html` é só a casca; o erro está no JS.
+  Verificar é abrir a página e olhar o console, ou ter teste de render.
+- **Variável `VITE_*` é embutida no build** — mudar o valor na Vercel exige redeploy.
+
+**Regras de trabalho com o dev** (herdadas; são o que mais muda o comportamento do modelo):
+
+- O dev mantém este código e precisa entender cada linha. **Explique cada mudança**; nada
+  de entregar caixa-preta para colar.
+- **Comentário no código só quando for load-bearing** — quando impede alguém de "consertar"
+  uma escolha deliberada. Explicação vai no PR e na conversa, não no arquivo.
+- **Rigor proporcional ao risco.** V1 atrasado: sem over-engineering, sem abstração
+  preventiva, sem suíte gigante.
+- **PR que remove código merece leitura dobrada:** apagar a definição e esquecer o uso é
+  exatamente o erro que derrubou o site, e o build não pega.

--- a/front-vassouras/.claude/hooks/lint-stop.mjs
+++ b/front-vassouras/.claude/hooks/lint-stop.mjs
@@ -1,0 +1,65 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+function lerStdin() {
+  try {
+    return JSON.parse(readFileSync(0, 'utf8') || '{}');
+  } catch {
+    return {};
+  }
+}
+
+// status null distingue "nao consegui rodar o comando" de "o comando rodou e reprovou".
+// No Windows, spawnar npm.cmd sem shell estoura EINVAL, e tratar isso como lint reprovado
+// bloquearia todo turno com uma mensagem vazia.
+function rodar(comando) {
+  try {
+    const saida = execSync(comando, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    return { ok: true, saida };
+  } catch (erro) {
+    return {
+      ok: false,
+      naoRodou: erro.status === null || erro.status === undefined,
+      saida: `${erro.stdout ?? ''}${erro.stderr ?? ''}`.trim() || erro.message,
+    };
+  }
+}
+
+const sessao = lerStdin().session_id ?? 'sem-sessao';
+
+// So vale gastar alguns segundos de ESLint se mudou algum arquivo que o ESLint le.
+const git = rodar('git status --porcelain');
+const temJs =
+  git.ok &&
+  git.saida
+    .split('\n')
+    .some((linha) => /\.(js|jsx|mjs|cjs)$/.test(linha.trim().split(/\s+/).pop() ?? ''));
+
+if (!temJs) process.exit(0);
+
+const lint = rodar('npm run lint');
+
+if (lint.ok) {
+  rmSync(join(tmpdir(), `vassouras-lint-${sessao}.flag`), { force: true });
+  process.exit(0);
+}
+
+// Hook quebrado avisa, mas nunca trava a sessao.
+if (lint.naoRodou) {
+  console.error(`hook de lint nao conseguiu rodar npm: ${lint.saida}`);
+  process.exit(0);
+}
+
+// Trava anti-loop: um erro que o modelo nao consegue corrigir prenderia a sessao num ciclo
+// infinito de "nao pode parar", porque o exit 2 do hook Stop bloqueia o encerramento.
+const marcador = join(tmpdir(), `vassouras-lint-${sessao}.flag`);
+if (existsSync(marcador)) {
+  console.error('npm run lint continua falhando; o hook nao bloqueia de novo nesta sessao.');
+  process.exit(0);
+}
+
+writeFileSync(marcador, '');
+console.error(`npm run lint falhou. Corrija os erros abaixo antes de encerrar.\n\n${lint.saida}`);
+process.exit(2);

--- a/front-vassouras/.claude/settings.json
+++ b/front-vassouras/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/lint-stop.mjs",
+            "timeout": 120,
+            "statusMessage": "Rodando npm run lint"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/front-vassouras/CLAUDE.md
+++ b/front-vassouras/CLAUDE.md
@@ -1,0 +1,124 @@
+# Vassouras Pernambucanas — front
+
+Catálogo B2B em React 19 + Vite 7 + React Router 7. SPA sem backend próprio: consome a API
+Django em `VITE_API_URL`.
+
+## Raiz e comandos
+
+A raiz do Vite é `front-vassouras/`, **não** a raiz do repositório git. Comando rodado um
+nível acima falha de um jeito confuso (npm não acha script, eslint não acha config).
+
+```
+npm run dev      # servidor local
+npm run build    # build de produção
+npm run lint     # eslint .
+npm test         # vitest em modo watch
+npx vitest --run # uma passada só (o que interessa antes de PR)
+```
+
+## Estrutura
+
+- `src/pages/` — uma página por rota, todas registradas em `App.jsx`.
+- `src/components/` — o que é reusado por mais de uma página (`ProdutoCard`, `ProdutosRow`,
+  `BotaoWhatsapp`, `Header`, `Footer`).
+- `src/services/` — o que fala com o mundo externo: `api.js` (rede), `ads.js` (gtag).
+- `src/utils/` — função pura, sem React (`embaralhar.js`, `GeraLinkWhatsapp.jsx`).
+- Teste fica ao lado do arquivo testado, como `Nome.test.jsx` (`components/Footer.test.jsx`,
+  `pages/ProdutoDetalhe.test.jsx`).
+
+## Convenções (cada uma comprovada em arquivo)
+
+**Vocabulário de domínio em português.** `buscarJson` (`services/api.js`), `embaralhar`
+(`utils/embaralhar.js`), `idCategoria` / `termoBusca` (`pages/Catalogo.jsx`),
+`registrarConversaoWhatsapp` (`services/ads.js`). Nos testes idem: `it('deve renderizar sem
+erro')` (`components/Footer.test.jsx`) — os arquivos novos escrevem os títulos sem acento.
+
+**Estilo só por classe utilitária do Tailwind no JSX.** Tailwind 4 pelo plugin
+`@tailwindcss/vite` (`vite.config.js`); não existe `tailwind.config.js`. `src/index.css` é
+uma linha (`@import "tailwindcss";`) e `src/App.css` está vazio. Não se escreve CSS novo
+neste projeto — valor arbitrário vai em colchete (`min-h-[45vh]` em `pages/Sobre.jsx`).
+
+**Toda chamada de rede passa por `buscarJson`** de `services/api.js`, com `API_BASE_URL`
+vindo de lá — a URL nunca é remontada à mão. O erro lançado carrega `erro.status`, e é isso
+que deixa `pages/ProdutoDetalhe.jsx` separar 404 (`'nao-encontrado'`) de falha de rede
+(`'falha'`).
+
+**`AbortController` + limpeza no `useEffect`** em toda busca: `Home.jsx`, `Catalogo.jsx` e
+os dois efeitos de `ProdutoDetalhe.jsx` criam o controller, passam o `signal` para
+`buscarJson`, ignoram `error.name === 'AbortError'` e abortam no return do efeito. A função
+async é chamada com `void fetchX()` — veio da limpeza de alertas do Sonar/IDE, mantenha.
+
+**Estados de tela explícitos: carregando / erro / vazio / com dado.** `Catalogo.jsx` trata
+os quatro; `ProdutoDetalhe.jsx` tem erro com botão "Tentar novamente" (contador `tentativa`
+como dependência do efeito, que é o que refaz a busca). Página que só trata o caminho feliz
+já custou defeito em produção aqui.
+
+**Debounce onde o usuário digita ou redimensiona.** 700 ms na busca do catálogo
+(`Catalogo.jsx`), 300 ms no resize de `ProdutosRow.jsx`. Ambos limpam o timer no return.
+
+**Variáveis de ambiente.** `VITE_API_URL` é só a origem, sem barra final e sem `/api` —
+`api.js` corta a barra e o caminho é montado no código. O gtag só carrega se
+`VITE_GADS_ID` existir (`services/ads.js`); sem a variável, nenhum script de terceiro e
+nenhum cookie entram na página.
+
+**Teste.** Vitest + Testing Library em jsdom (`vite.config.js`), `setupTests.js` faz
+`cleanup` e importa `jest-dom/vitest`. Padrão observado: `fetch` stubado com
+`vi.stubGlobal` e desfeito no `afterEach` (`App.test.jsx`), componente com `Link` renderiza
+dentro de `MemoryRouter` (`Footer.test.jsx`), env com `vi.stubEnv` (`ads.test.js`). Não há
+`@testing-library/user-event` em todo teste — só onde há clique.
+
+**ESLint.** `eslint.config.js` usa o recomendado + react-hooks + react-refresh, e ajusta
+`no-unused-vars` para ignorar identificadores `^[A-Z_]`. Um hook de Stop roda `npm run lint`
+ao fim do turno quando há `.js/.jsx` modificado (`.claude/hooks/lint-stop.mjs`).
+
+**Commits.** Conventional Commits com escopo opcional e mensagem em português sem acento:
+`fix(sonar): resolve alertas do SonarQube e das inspecoes da IDE`. O histórico antigo tem
+mensagens em inglês; para commit novo, siga o padrão em português.
+
+## Antes de abrir PR
+
+`npm run lint` **e** `npm test` (ou `npx vitest --run`), rodados dentro de
+`front-vassouras/`. Hoje os dois passam limpos — quebra é regressão sua.
+
+## Armadilhas desta stack
+
+- **Variável indefinida em JSX não quebra o build.** Para o Rollup ela é global livre, não
+  import faltando: compila, deploya e explode em runtime. Só o `no-undef` do ESLint ou um
+  teste de render pegam. Isso já derrubou o site inteiro uma vez.
+- **Erro em `Header` ou `Footer` derruba o app inteiro**, não só o componente: os dois são
+  irmãos de `<Routes>` em `App.jsx` e não existe error boundary.
+- **HTTP 200 não prova que a SPA funciona.** `index.html` é só a casca (e o `vercel.json`
+  reescreve toda rota para ela); o erro está no JS. Verificar é abrir a página e olhar o
+  console, ou ter teste de render.
+- **Variável `VITE_*` é embutida no build** — mudar o valor na Vercel exige redeploy.
+
+## Trabalho com o dev
+
+- O dev mantém este código e precisa entender cada linha. **Explique cada mudança**; nada de
+  caixa-preta para colar.
+- **Comentário no código só quando for load-bearing**, isto é, quando impede alguém de
+  "consertar" uma escolha deliberada — como o comentário sobre `function` e `arguments` em
+  `services/ads.js`. O resto da explicação vai no PR e na conversa.
+- **Rigor proporcional ao risco.** V1 atrasado: sem over-engineering, sem abstração
+  preventiva, sem suíte gigante.
+- **PR que remove código merece leitura dobrada:** apagar a definição e esquecer o uso é
+  exatamente o erro que derrubou o site, e o build não pega.
+
+## Inconsistências conhecidas (decidir, não "consertar" de passagem)
+
+- **Formatação:** 13 arquivos com 2 espaços e `import { x }` (majoritário, e é o estilo de
+  tudo que é recente: `ads.js`, `Catalogo.jsx`, os testes) contra 8 com 4 espaços e
+  `import {x}` (`App.jsx`, `ProdutoDetalhe.jsx`, `ProdutoCard.jsx`, `ProdutosRow.jsx`,
+  `Footer.jsx`, `Contatos.jsx`, `api.js`, `GeraLinkWhatsapp.jsx`). Não há Prettier nem
+  `.editorconfig` no repositório; a formatação de 4 espaços veio do WebStorm.
+- **Declaração de componente:** páginas e `Header`/`Footer` usam `function Nome()`;
+  `ProdutoCard`, `ProdutosRow` e `BotaoWhatsapp` usam `const Nome = () =>`.
+- **Nome do estado de erro/carregamento:** `isLoading`/`error` em `Home.jsx` e
+  `Catalogo.jsx`, contra `erro`/`loadingRelacionados` em `ProdutoDetalhe.jsx`.
+- **`ProdutosRow` recebe uma prop que não consome:** `ProdutoDetalhe.jsx` passa
+  `loading={loadingRelacionados}`, mas a assinatura em `ProdutosRow.jsx` é
+  `({titulo, produtos})` — não existe estado de carregamento nessa faixa.
+- **`Home.jsx` não trata lista vazia** (só `produtos.length > 0`), enquanto `Catalogo.jsx`
+  mostra "Nenhum produto encontrado.".
+- **`utils/GeraLinkWhatsapp.jsx` não contém JSX** e mesmo assim usa a extensão `.jsx`,
+  diferente de `utils/embaralhar.js`.


### PR DESCRIPTION
Fecha o CP0 do plano de checkpoints. Junto com o `1471fae` (o `.gitignore`, que ja esta na `main`), tira da maquina local as duas pecas que deveriam proteger o repositorio.

## O que entra

**`.claude/hooks/lint-stop.mjs` + `.claude/settings.json`** — hook de `Stop` que roda `npm run lint` ao fim de cada turno, mas so quando ha `.js`/`.jsx`/`.mjs`/`.cjs` modificado (nao vale gastar segundos de ESLint num turno que so mexeu em markdown).

Por que isso nao e burocracia: o PR #18 removeu o `import` de `API_BASE_URL` e a const `adminUrl`, mas deixou o `<li>` que usava a variavel. Para o Rollup ela virou global livre, nao import faltando — o build passou, o deploy passou, e o site ficou com tela branca em **todas** as rotas, porque o `Footer` e irmao de `<Routes>` e nao ha error boundary. `npm run lint` (`no-undef`) teria pego. O script ja existia e nunca tinha sido rodado.

Dois detalhes do hook que sao deliberados e valem a leitura:

- **`status === null` distingue "nao consegui rodar o comando" de "o comando rodou e reprovou".** No Windows, spawnar `npm.cmd` sem shell estoura `EINVAL`; tratar isso como lint reprovado bloquearia todo turno com uma mensagem vazia. Hook quebrado avisa, mas nunca trava a sessao.
- **Trava anti-loop por `session_id`.** O `exit 2` do hook `Stop` impede a sessao de encerrar. Sem a trava, um erro de lint que o modelo nao consegue corrigir prenderia a sessao num ciclo infinito de "nao pode parar". O marcador fica em `os.tmpdir()`; lint verde apaga.

**`.claude/agents/documentador-padroes.md`** — subagente que mantem o `CLAUDE.md`.

**`CLAUDE.md`** — convencoes do projeto, cada uma ancorada num arquivo real: raiz do Vite em `front-vassouras/`, vocabulario de dominio em portugues, estilo so por Tailwind, rede sempre via `buscarJson` + `AbortController`, estados de tela explicitos, padrao de teste, Conventional Commits.

## O que fica de fora, de proposito

`.claude/settings.local.json` e `.mcp.json` entraram no `.gitignore`. O primeiro e preferencia de maquina; o segundo guarda a porta local do MCP do WebStorm (`127.0.0.1:64542`), que muda a cada sessao — versionar geraria conflito toda vez que o projeto fosse aberto.

## Divisao de responsabilidade

O `CLAUDE.md` e **so convencao e comando**; estado, historico e decisoes continuam no `HANDOFF-vassouras.md`. Se os dois contarem a mesma historia, o `CLAUDE.md` vira peso morto — ele entra em *todo* contexto.

## Verificacao

`npm run lint` exit 0 e 17/17 testes verdes em 5 arquivos. Nenhum arquivo de `src/` foi tocado: o diff e so configuracao e documentacao.

⚠️ Hook de projeto so dispara depois de aceitar o **workspace trust** da pasta. Se parecer que nao roda, e o primeiro lugar a checar (`claude --debug` mostra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)