### PR TITLE
fix: corrige a divida tecnica acumulada do front

### DIFF
--- a/front-vassouras/index.html
+++ b/front-vassouras/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/front-vassouras/src/App.jsx
+++ b/front-vassouras/src/App.jsx
@@ -4,6 +4,7 @@ import Catalogo from './pages/Catalogo.jsx';
 import ProdutoDetalhe from './pages/ProdutoDetalhe.jsx';
 import Contatos from './pages/Contatos.jsx';
 import Sobre from './pages/Sobre.jsx';
+import NaoEncontrada from './pages/NaoEncontrada.jsx';
 import Header from './components/Header.jsx';
 import Footer from './components/Footer.jsx';
 import {BrowserRouter, Route, Routes} from 'react-router-dom';
@@ -11,7 +12,7 @@ import {BrowserRouter, Route, Routes} from 'react-router-dom';
 function App() {
     return (
         <BrowserRouter>
-            <div className='flex flex-col min-h-screen bg-gray-50"'>
+            <div className='flex flex-col min-h-screen bg-gray-50'>
                 <Header/>
                 <main className='grow w-full  mx-auto'>
                     <Routes>
@@ -20,6 +21,7 @@ function App() {
                         <Route path='/produto/:id' element={<ProdutoDetalhe/>}/>
                         <Route path='/contatos/' element={<Contatos/>}/>
                         <Route path='/sobre/' element={<Sobre/>}/>
+                        <Route path='*' element={<NaoEncontrada/>}/>
                     </Routes>
                 </main>
                 <Footer/>

--- a/front-vassouras/src/App.test.jsx
+++ b/front-vassouras/src/App.test.jsx
@@ -18,6 +18,7 @@ describe('App', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    window.history.pushState({}, '', '/');
   });
 
   it('deve montar a aplicacao sem erro', async () => {
@@ -27,5 +28,15 @@ describe('App', () => {
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
 
     await waitFor(() => expect(fetch).toHaveBeenCalled());
+  });
+
+  it('deve exibir a pagina de nao encontrada numa rota que nao existe', () => {
+    window.history.pushState({}, '', '/rota-que-nao-existe');
+
+    render(<App />);
+
+    expect(screen.getByText('Página não encontrada')).toBeInTheDocument();
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
   });
 });

--- a/front-vassouras/src/components/ProdutoCard.jsx
+++ b/front-vassouras/src/components/ProdutoCard.jsx
@@ -1,4 +1,5 @@
 import {Link} from 'react-router-dom';
+import {formatarPreco} from '../utils/formatarPreco.js';
 
 const ProdutoCard = ({produto}) => {
     return (
@@ -23,7 +24,7 @@ const ProdutoCard = ({produto}) => {
                 </h2>
 
                 <p className='text-blue-600 font-bold mt-2 text-sm sm:text-base'>
-                    R$ {produto.preco}
+                    {formatarPreco(produto.preco)}
                 </p>
             </div>
         </Link>

--- a/front-vassouras/src/pages/Catalogo.jsx
+++ b/front-vassouras/src/pages/Catalogo.jsx
@@ -10,17 +10,31 @@ function Catalogo() {
 
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [erroCategorias, setErroCategorias] = useState(null);
 
   useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
     async function fetchCategorias() {
+      setErroCategorias(null);
       try {
-        const data = await buscarJson(`${API_BASE_URL}/api/categorias/`);
-        setCategorias(data);
+        const data = await buscarJson(
+          `${API_BASE_URL}/api/categorias/`,
+          signal
+        );
+        if (!signal.aborted) setCategorias(data);
       } catch (error) {
-        console.error('Erro ao processar categorias:', error);
+        if (error.name === 'AbortError') return;
+        if (!signal.aborted) {
+          setErroCategorias('Não foi possível carregar as categorias.');
+          console.error('Erro ao processar categorias:', error);
+        }
       }
     }
     void fetchCategorias();
+
+    return () => controller.abort();
   }, []);
 
   useEffect(() => {
@@ -43,10 +57,7 @@ function Catalogo() {
           setIsLoading(false);
         }
       } catch (err) {
-        if (err.name === 'AbortError') {
-          console.log('Requisição abortada');
-          return;
-        }
+        if (err.name === 'AbortError') return;
         if (!signal.aborted) {
           setError('Erro ao carregar produtos.');
           setIsLoading(false);
@@ -69,7 +80,7 @@ function Catalogo() {
         <h1 className='text-5xl md:text-4xl font-black text-white drop-shadow-md'>
           Catálogo de <span className='text-yellow-400'>Produtos</span>
         </h1>
-        <p className='text-lg md:text-xl text-white/90 mt-2 max-w-1xl mx-auto leading-relaxed'>
+        <p className='text-lg md:text-xl text-white/90 mt-2 max-w-xl mx-auto leading-relaxed'>
           Encontre as melhores opções para o seu negócio.
         </p>
       </div>
@@ -94,6 +105,10 @@ function Catalogo() {
           >
             Todos
           </button>
+
+          {erroCategorias && (
+            <p className='px-4 py-3 text-sm text-red-500'>{erroCategorias}</p>
+          )}
 
           {categorias.map((categoria) => (
             <button
@@ -130,7 +145,9 @@ function Catalogo() {
           {!isLoading && !error && produtos.length > 0 && (
             <ul className='w-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-6'>
               {produtos.map((produto) => (
-                <ProdutoCard key={produto.id} produto={produto} />
+                <li key={produto.id}>
+                  <ProdutoCard produto={produto} />
+                </li>
               ))}
             </ul>
           )}

--- a/front-vassouras/src/pages/Catalogo.test.jsx
+++ b/front-vassouras/src/pages/Catalogo.test.jsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Catalogo from './Catalogo';
+
+const CATEGORIAS = [
+  { id: 2, nome: 'Escovas' },
+  { id: 3, nome: 'Vassouras' },
+];
+
+const resposta = (corpo, status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(corpo),
+  });
+
+function renderizar() {
+  return render(
+    <MemoryRouter>
+      <Catalogo />
+    </MemoryRouter>
+  );
+}
+
+describe('Catalogo', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('deve listar as categorias quando a api responde', async () => {
+    fetch.mockImplementation((url) =>
+      url.includes('/categorias/') ? resposta(CATEGORIAS) : resposta([])
+    );
+
+    renderizar();
+
+    expect(await screen.findByText('Escovas')).toBeInTheDocument();
+    expect(screen.getByText('Vassouras')).toBeInTheDocument();
+  });
+
+  // O catalogo mostrava "R$ 20.00" enquanto a PDP mostrava "R$ 20,00" para o mesmo produto.
+  it('deve formatar o preco do card em pt-BR', async () => {
+    fetch.mockImplementation((url) =>
+      url.includes('/categorias/')
+        ? resposta([])
+        : resposta([{ id: 7, nome: 'Escova Oval', preco: '20.00', imagem: null }])
+    );
+
+    renderizar();
+
+    expect(await screen.findByText('R$ 20,00')).toBeInTheDocument();
+  });
+
+  it('deve avisar quando a busca de categorias falha', async () => {
+    fetch.mockImplementation((url) =>
+      url.includes('/categorias/') ? resposta(null, 500) : resposta([])
+    );
+
+    renderizar();
+
+    expect(
+      await screen.findByText('Não foi possível carregar as categorias.')
+    ).toBeInTheDocument();
+  });
+
+  // O botao "Todos" e estatico. Sem esta assercao, a falha de categorias ficaria
+  // indistinguivel do estado normal — que era exatamente o defeito em producao.
+  it('nao deve confundir falha de categorias com catalogo sem categoria', async () => {
+    fetch.mockImplementation((url) =>
+      url.includes('/categorias/') ? resposta([]) : resposta([])
+    );
+
+    renderizar();
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+    expect(screen.getByText('Todos')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Não foi possível carregar as categorias.')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/front-vassouras/src/pages/Contatos.jsx
+++ b/front-vassouras/src/pages/Contatos.jsx
@@ -87,10 +87,7 @@ function Contatos() {
                         WhatsApp. Respondemos em média em até 30 minutos.
                     </p>
 
-                    <BotaoWhatsapp
-                        produto={null}
-                        className='self-start bg-green-500 hover:bg-green-600 text-white font-bold py-3 px-6 rounded-lg shadow-md transition-transform hover:scale-105 flex items-center gap-2'
-                    />
+                    <BotaoWhatsapp produto={null}/>
                 </div>
             </div>
 

--- a/front-vassouras/src/pages/Home.jsx
+++ b/front-vassouras/src/pages/Home.jsx
@@ -24,10 +24,7 @@ function Home() {
           setIsLoading(false);
         }
       } catch (error) {
-        if (error.name === 'AbortError') {
-          console.log('Requisição abortada');
-          return;
-        }
+        if (error.name === 'AbortError') return;
         if (!signal.aborted) {
           setError('Erro ao carregar produtos.');
           setIsLoading(false);

--- a/front-vassouras/src/pages/NaoEncontrada.jsx
+++ b/front-vassouras/src/pages/NaoEncontrada.jsx
@@ -1,0 +1,17 @@
+import {Link} from 'react-router-dom';
+
+function NaoEncontrada() {
+    return (
+        <div className='p-10 text-center flex flex-col items-center gap-4'>
+            <h1 className='text-2xl font-bold text-gray-900'>Página não encontrada</h1>
+            <p className='text-gray-600'>
+                O endereço que você abriu não existe ou foi movido.
+            </p>
+            <Link to='/produtos' className='text-blue-600 underline'>
+                Ver todos os produtos
+            </Link>
+        </div>
+    );
+}
+
+export default NaoEncontrada;

--- a/front-vassouras/src/pages/ProdutoDetalhe.jsx
+++ b/front-vassouras/src/pages/ProdutoDetalhe.jsx
@@ -4,6 +4,7 @@ import BotaoWhatsapp from '../components/BotaoWhatsapp';
 import ProdutosRow from '../components/ProdutosRow.jsx';
 import {API_BASE_URL, buscarJson} from '../services/api.js';
 import {embaralhar} from '../utils/embaralhar.js';
+import {formatarPreco} from '../utils/formatarPreco.js';
 
 function ProdutoDetalhe() {
     const {id} = useParams();
@@ -11,11 +12,16 @@ function ProdutoDetalhe() {
     const [erro, setErro] = useState(null);
     const [tentativa, setTentativa] = useState(0);
     const [relacionados, setRelacionados] = useState([]);
-    const [loadingRelacionados, setLoadingRelacionados] = useState(false);
 
     useEffect(() => {
         const controller = new AbortController();
 
+        // Este reset limpa o produto velho ao trocar de id E limpa o erro no retry
+        // (tentativa e dependencia do efeito). Tirar os dois exige remontar por key ou
+        // derivar o estado, e as duas saidas quebram o retry. Fica para o CP5, que ja
+        // reescreve a navegacao da PDP. A regra so aparece desde que o estado morto
+        // loadingRelacionados saiu daqui e a analise parou de fazer bailout.
+        // eslint-disable-next-line react-hooks/set-state-in-effect
         setProduto(null);
         setErro(null);
         window.scrollTo(0, 0);
@@ -46,7 +52,6 @@ function ProdutoDetalhe() {
         const controller = new AbortController();
 
         async function fetchRelacionados() {
-            setLoadingRelacionados(true);
             try {
                 const data = await buscarJson(
                     `${API_BASE_URL}/api/produtos/?categoria=${produto.categoria}`,
@@ -60,8 +65,6 @@ function ProdutoDetalhe() {
                 if (error.name !== 'AbortError') {
                     console.error('Erro ao buscar produtos relacionados:', error);
                 }
-            } finally {
-                setLoadingRelacionados(false);
             }
         }
 
@@ -69,13 +72,6 @@ function ProdutoDetalhe() {
 
         return () => controller.abort();
     }, [produto?.categoria, produto?.id]);
-
-    const formatarPreco = (valor) => {
-        return new Intl.NumberFormat('pt-BR', {
-            style: 'currency',
-            currency: 'BRL',
-        }).format(valor);
-    };
 
     if (erro) {
         const naoEncontrado = erro === 'nao-encontrado';
@@ -149,12 +145,8 @@ function ProdutoDetalhe() {
                 </div>
             </div>
 
-            {(loadingRelacionados || relacionados.length > 0) && (
-                <ProdutosRow
-                    titulo='Veja também'
-                    produtos={relacionados}
-                    loading={loadingRelacionados}
-                />
+            {relacionados.length > 0 && (
+                <ProdutosRow titulo='Veja também' produtos={relacionados}/>
             )}
         </div>
     );

--- a/front-vassouras/src/pages/Sobre.jsx
+++ b/front-vassouras/src/pages/Sobre.jsx
@@ -24,7 +24,7 @@ function Sobre() {
       </div>
 
       <div className='CardsContainer grid grid-cols-1 md:grid-cols-3 gap-8 mt-10'>
-        <div className='relative bg-color-neutral-300 rounded-[35px] pt-[40px] px-[30px] pb-[30px] text-center text-white flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
+        <div className='relative bg-neutral-300 rounded-[35px] pt-[40px] px-[30px] pb-[30px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
           <h2 className='text-3xl font-bold text-blue-500'>Missão</h2>
           <p className='text-zinc-600 font-bold leading-relaxed'>
             Nossa missão é fornecer vassouras de alta qualidade que atendam às
@@ -33,7 +33,7 @@ function Sobre() {
           </p>
         </div>
 
-        <div className='relative bg-color-neutral-300   rounded-[35px] pt-[40px] px-[30px] pb-[70px] text-center text-white flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
+        <div className='relative bg-neutral-300 rounded-[35px] pt-[40px] px-[30px] pb-[70px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
           <h2 className='text-3xl font-bold text-blue-500'>Visão</h2>
           <p className='text-zinc-600 font-bold leading-relaxed'>
             Ser reconhecida como a principal fabricante de vassouras no mercado,
@@ -42,7 +42,7 @@ function Sobre() {
           </p>
         </div>
 
-        <div className='relative bg-color-neutral-300 rounded-[35px] pt-[40px] px-[30px] pb-[30px] text-center text-white flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
+        <div className='relative bg-neutral-300 rounded-[35px] pt-[40px] px-[30px] pb-[30px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
           <h2 className='text-3xl font-bold text-blue-500'>Valores</h2>
           <ul className='text-left text-zinc-800 space-y-2'>
             <li className='font-bold text-zinc-600 leading-relaxed'>

--- a/front-vassouras/src/utils/formatarPreco.js
+++ b/front-vassouras/src/utils/formatarPreco.js
@@ -1,0 +1,6 @@
+export function formatarPreco(valor) {
+    return new Intl.NumberFormat('pt-BR', {
+        style: 'currency',
+        currency: 'BRL',
+    }).format(valor);
+}

--- a/front-vassouras/vercel.json
+++ b/front-vassouras/vercel.json
@@ -4,5 +4,15 @@
       "source": "/(.*)",
       "destination": "/index.html"
     }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
CP2 do plano de checkpoints. **Onze correcoes pequenas**, todas em codigo que o trafego pago vai atravessar. Nenhuma muda arquitetura.

**Testes: 17 → 22.** Os tres novos foram vistos **vermelhos antes** da correcao (principio #2) — comprovado desfazendo cada fix e rodando a suite.

## Acessibilidade e SEO

- `index.html`: `lang="en"` → `pt-BR` num site inteiramente em portugues. Leitor de tela pronunciava tudo errado.
- **Rota catch-all** com pagina "Pagina nao encontrada". Antes, URL inexistente renderizava o layout com o miolo vazio.
  ⚠️ Ela **ainda responde HTTP 200**, por causa do rewrite do `vercel.json`. Limitacao aceita da SPA — registrada, nao resolvida aqui.

## Classes que falhavam em silencio

| Onde | O que estava errado |
|---|---|
| `App.jsx:14` | aspa dupla sobrando dentro do `className` gerava a classe literal `bg-gray-50"` — o fundo cinza da aplicacao **nunca era aplicado** |
| `Sobre.jsx:27,36,45` | `bg-color-neutral-300` nao existe: alguem misturou o nome da variavel `--color-neutral-300` do Tailwind 4 com o da classe. Os tres cards renderizavam **sem fundo** |
| `Catalogo.jsx:72` | `max-w-1xl` nao existe → `max-w-xl` |

No `Sobre` tirei junto o `text-white` morto do container. Todos os filhos ja sobrescrevem a cor — por isso o texto sempre foi legivel, ao contrario do que a analise de 02/08 afirmava. Deixa-lo la e uma armadilha para quem adicionar um filho sem classe de cor depois.

## Props mortas

- `ProdutoDetalhe` passava `loading` para `ProdutosRow`, cuja assinatura e `({titulo, produtos})`. Alem de ignorada, a condicao de render usava esse estado e mostrava **"Veja tambem" vazio durante o carregamento**. Sem a prop, `loadingRelacionados` ficou sem leitor e saiu junto.
- `Contatos` passava `className` para `BotaoWhatsapp`, que desestrutura so `{produto}`. **Removida em vez de suportada:** o estilo passado (`py-3 px-6 rounded-lg`) conflita com o do componente (`p-6 rounded-2xl`), e aceitar a prop mudaria a aparencia atual sem que ninguem tenha pedido. Conferido no navegador: a pagina esta identica.

## O estado de erro que faltava

O fetch de categorias do `Catalogo` nao tinha `AbortController` nem estado de erro — so `console.error`. Quando falhava, a barra lateral mostrava so "Todos", **visualmente identica ao estado normal**: o visitante nao tinha como saber que a filtragem quebrou. Era pior que o item #31 original, que ao menos deixava um spinner denunciando.

Agora segue o padrao dos outros efeitos do arquivo, e ha teste cobrindo os dois lados — falha avisa, catalogo legitimamente sem categoria **nao** avisa.

## Consistencia

- `formatarPreco` saiu de dentro do `ProdutoDetalhe` para `utils/` e o `ProdutoCard` passou a usar. O mesmo produto aparecia como **"R$ 20.00"** no catalogo e **"R$ 20,00"** na PDP — confirmado lado a lado em producao.
- `console.log('Requisicao abortada')` removido de `Catalogo` e `Home`.

## Infra

`vercel.json` ganhou `X-Content-Type-Options`, `X-Frame-Options` e `Referrer-Policy`. O front nao mandava **nenhum** header de seguranca; so o HSTS que a Vercel adiciona sozinha.

## Um eslint-disable, e por que ele esta ai

Ao remover o estado morto `loadingRelacionados`, a analise do `react-hooks` **parou de fazer bailout** e passou a reportar `set-state-in-effect` no `setProduto(null)` do primeiro efeito. Confirmei por bisseccao: na `main` limpa o arquivo passa; removendo so o `setLoadingRelacionados(true)` tambem passa; o gatilho e a remocao do estado.

Ou seja: **o anti-padrao sempre existiu e estava escondido.** Corrigir de verdade exige remontar por `key` ou derivar o estado, e as duas saidas quebram o retry — que tem teste (`nao deve manter o erro ao trocar de produto`). Isso e refatoracao do modelo de estado da PDP, nao divida barata. **Fica para o CP5**, que ja reescreve a navegacao daquela pagina. O motivo esta no comentario, ao lado do disable.

## Verificacao

`npm run lint` exit 0 · **22/22 testes** em 6 arquivos · `npm run build` ok. No navegador: pagina 404 com header e rodapé intactos, fundo cinza aparecendo pela primeira vez, cards do Sobre com fundo, Contatos inalterado.

⚠️ Preco e categorias nao dao para validar fora da Vercel — o CORS do backend nao libera `localhost`. **Depois do merge, abrir `/produtos` e conferir "R$ 20,00" no card.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)