### PR TITLE
feat(logo): logo do cliente no header, favicon e pasta public/

### DIFF
--- a/front-vassouras/index.html
+++ b/front-vassouras/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Vassouras Pernambucanas</title>
   </head>
   <body>

--- a/front-vassouras/public/favicon.svg
+++ b/front-vassouras/public/favicon.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-label="Vassouras Pernambucanas">
+  <title>Vassouras Pernambucanas</title>
+
+  <defs>
+    <clipPath id="recorte-pe">
+      <path d="M6,49 C4,33 10,23 22,20 L48,17 L70,23 L88,15 L112,20 L132,12 L150,20 L164,4 L180,15 L200,9 L216,20 L232,12 L244,25 L258,15 L276,20 L296,12 L318,17 L338,12 C352,15 360,25 360,41 L356,63 C354,76 344,84 332,81 L308,84 L286,76 L262,86 L240,81 L216,94 L194,89 L172,102 L150,97 L128,110 L106,105 L84,118 C66,126 46,121 32,105 C18,92 8,70 6,49 Z"/>
+    </clipPath>
+  </defs>
+
+  <rect width="400" height="400" rx="64" fill="#1D4ED8"/>
+
+  <g transform="translate(4, 130) scale(1.08)">
+    <g clip-path="url(#recorte-pe)">
+      <rect width="364" height="70" fill="#002776"/>
+      <rect y="70" width="364" height="60" fill="#FFFFFF"/>
+
+      <path d="M-14,58 Q182,-30 378,58" fill="none" stroke="#C8102E" stroke-width="10"/>
+      <path d="M-14,68 Q182,-20 378,68" fill="none" stroke="#F5C400" stroke-width="10"/>
+      <path d="M-14,78 Q182,-10 378,78" fill="none" stroke="#009639" stroke-width="10"/>
+
+      <path d="M197,55 L189.7,57.1 L195,62.5 L187.7,60.7 L189.5,68 L184.1,62.7 L182,70 L179.9,62.7 L174.5,68 L176.3,60.7 L169,62.5 L174.3,57.1 L167,55 L174.3,52.9 L169,47.5 L176.3,49.3 L174.5,42 L179.9,47.3 L182,40 L184.1,47.3 L189.5,42 L187.7,49.3 L195,47.5 L189.7,52.9 Z" fill="#F5C400"/>
+      <circle cx="182" cy="55" r="9" fill="#F5C400"/>
+
+      <path d="M178,76 L186,76 L186,81 L197,81 L197,89 L186,89 L186,96 L178,96 L178,89 L167,89 L167,81 L178,81 Z" fill="#C8102E"/>
+    </g>
+
+    <path d="M6,49 C4,33 10,23 22,20 L48,17 L70,23 L88,15 L112,20 L132,12 L150,20 L164,4 L180,15 L200,9 L216,20 L232,12 L244,25 L258,15 L276,20 L296,12 L318,17 L338,12 C352,15 360,25 360,41 L356,63 C354,76 344,84 332,81 L308,84 L286,76 L262,86 L240,81 L216,94 L194,89 L172,102 L150,97 L128,110 L106,105 L84,118 C66,126 46,121 32,105 C18,92 8,70 6,49 Z" fill="none" stroke="#FFFFFF" stroke-width="3"/>
+  </g>
+</svg>

--- a/front-vassouras/src/App.test.jsx
+++ b/front-vassouras/src/App.test.jsx
@@ -39,4 +39,20 @@ describe('App', () => {
     expect(screen.getByRole('banner')).toBeInTheDocument();
     expect(screen.getByRole('contentinfo')).toBeInTheDocument();
   });
+
+  it('deve ter um unico h1 na home', async () => {
+    render(<App />);
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+  });
+
+  it('deve ter um unico h1 na pagina de nao encontrada', () => {
+    window.history.pushState({}, '', '/rota-que-nao-existe');
+
+    render(<App />);
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+  });
 });

--- a/front-vassouras/src/components/Header.jsx
+++ b/front-vassouras/src/components/Header.jsx
@@ -1,6 +1,7 @@
 import { Link, NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import { Menu, X } from 'lucide-react';
+import Logo from './Logo.jsx';
 
 const getNavClasses = (isActive) => {
   const baseClasses =
@@ -26,7 +27,7 @@ function Header() {
     <header className='relative bg-white shadow-sm sticky top-0 z-50'>
       <div className='headercontainer mx-auto flex items-center justify-between px-6 py-4'>
         <Link to='/'>
-          <h1 className='text-2xl font-bold'>Logo</h1>
+          <Logo reduzida className='h-14 w-auto' />
         </Link>
 
         <ul className='hidden md:flex space-x-8'>

--- a/front-vassouras/src/components/Header.test.jsx
+++ b/front-vassouras/src/components/Header.test.jsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import Header from './Header';
+
+const renderizarHeader = () =>
+  render(
+    <MemoryRouter>
+      <Header />
+    </MemoryRouter>
+  );
+
+describe('Header', () => {
+  it('deve renderizar sem erro', () => {
+    renderizarHeader();
+
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+
+  it('deve exibir a logo com nome acessivel', () => {
+    renderizarHeader();
+
+    expect(
+      screen.getByRole('img', { name: /vassouras pernambucanas/i })
+    ).toBeInTheDocument();
+  });
+
+  it('deve levar a logo para a home', () => {
+    renderizarHeader();
+
+    const link = screen.getByRole('link', { name: /vassouras pernambucanas/i });
+
+    expect(link).toHaveAttribute('href', '/');
+  });
+
+  it('nao deve conter h1, que pertence a pagina', () => {
+    renderizarHeader();
+
+    expect(screen.queryAllByRole('heading', { level: 1 })).toHaveLength(0);
+  });
+});

--- a/front-vassouras/src/components/Logo.jsx
+++ b/front-vassouras/src/components/Logo.jsx
@@ -1,0 +1,124 @@
+import { useId } from 'react';
+
+const CONTORNO_PERNAMBUCO =
+  'M6,49 C4,33 10,23 22,20 L48,17 L70,23 L88,15 L112,20 L132,12 L150,20 ' +
+  'L164,4 L180,15 L200,9 L216,20 L232,12 L244,25 L258,15 L276,20 L296,12 ' +
+  'L318,17 L338,12 C352,15 360,25 360,41 L356,63 C354,76 344,84 332,81 ' +
+  'L308,84 L286,76 L262,86 L240,81 L216,94 L194,89 L172,102 L150,97 ' +
+  'L128,110 L106,105 L84,118 C66,126 46,121 32,105 C18,92 8,70 6,49 Z';
+
+const RAIOS_DO_SOL =
+  'M197,55 L189.7,57.1 L195,62.5 L187.7,60.7 L189.5,68 L184.1,62.7 L182,70 ' +
+  'L179.9,62.7 L174.5,68 L176.3,60.7 L169,62.5 L174.3,57.1 L167,55 ' +
+  'L174.3,52.9 L169,47.5 L176.3,49.3 L174.5,42 L179.9,47.3 L182,40 ' +
+  'L184.1,47.3 L189.5,42 L187.7,49.3 L195,47.5 L189.7,52.9 Z';
+
+const CRUZ =
+  'M178,76 L186,76 L186,81 L197,81 L197,89 L186,89 L186,96 L178,96 ' +
+  'L178,89 L167,89 L167,81 L178,81 Z';
+
+const PILHA_DE_FONTES =
+  "'Arial Narrow','Helvetica Neue',Helvetica,Arial,sans-serif";
+
+const Logo = ({ reduzida = false, className = 'h-14 w-auto' }) => {
+  const id = useId();
+  const idTitulo = `${id}-titulo`;
+  const idRecorte = `${id}-recorte`;
+
+  return (
+    <svg
+      viewBox='0 0 400 240'
+      role='img'
+      aria-labelledby={idTitulo}
+      className={className}
+    >
+      <title id={idTitulo}>Vassouras Pernambucanas</title>
+
+      <rect width='400' height='240' rx='18' fill='#1D4ED8' />
+
+      {/* textLength e load-bearing: e ele que faz as duas palavras terem a
+          mesma largura, como na logo do cliente, independente da fonte que a
+          maquina do visitante tiver. Sem ele a logo se desmonta em quem nao
+          tem uma sans condensada instalada. */}
+      <text
+        x='200'
+        y='58'
+        textLength='364'
+        lengthAdjust='spacingAndGlyphs'
+        textAnchor='middle'
+        fontFamily={PILHA_DE_FONTES}
+        fontSize='60'
+        fontWeight='700'
+        fill='#FFFFFF'
+      >
+        VASSOURAS
+      </text>
+
+      <g transform='translate(18, 56)'>
+        {reduzida ? (
+          <path d={CONTORNO_PERNAMBUCO} fill='#FFFFFF' />
+        ) : (
+          <>
+            <defs>
+              <clipPath id={idRecorte}>
+                <path d={CONTORNO_PERNAMBUCO} />
+              </clipPath>
+            </defs>
+
+            <g clipPath={`url(#${idRecorte})`}>
+              <rect width='364' height='70' fill='#002776' />
+              <rect y='70' width='364' height='60' fill='#FFFFFF' />
+
+              <path
+                d='M-14,58 Q182,-30 378,58'
+                fill='none'
+                stroke='#C8102E'
+                strokeWidth='10'
+              />
+              <path
+                d='M-14,68 Q182,-20 378,68'
+                fill='none'
+                stroke='#F5C400'
+                strokeWidth='10'
+              />
+              <path
+                d='M-14,78 Q182,-10 378,78'
+                fill='none'
+                stroke='#009639'
+                strokeWidth='10'
+              />
+
+              <path d={RAIOS_DO_SOL} fill='#F5C400' />
+              <circle cx='182' cy='55' r='9' fill='#F5C400' />
+
+              <path d={CRUZ} fill='#C8102E' />
+            </g>
+
+            <path
+              d={CONTORNO_PERNAMBUCO}
+              fill='none'
+              stroke='#FFFFFF'
+              strokeWidth='3'
+            />
+          </>
+        )}
+      </g>
+
+      <text
+        x='200'
+        y='228'
+        textLength='364'
+        lengthAdjust='spacingAndGlyphs'
+        textAnchor='middle'
+        fontFamily={PILHA_DE_FONTES}
+        fontSize='48'
+        fontWeight='700'
+        fill='#FFFFFF'
+      >
+        PERNAMBUCANAS
+      </text>
+    </svg>
+  );
+};
+
+export default Logo;


### PR DESCRIPTION
Fecha o **CP3** da seção 14 do HANDOFF — o primeiro dos três pedidos novos do cliente (12.3).

## O que entra

| Arquivo | O quê |
| --- | --- |
| `src/components/Logo.jsx` (novo) | SVG inline, sem dependência nova. Duas variantes |
| `src/components/Header.jsx` | `<h1>Logo</h1>` → `<Logo reduzida />` |
| `public/favicon.svg` (pasta nova) | Marca quadrada; o Vite serve `public/` na raiz sozinho |
| `index.html` | `<link rel="icon" type="image/svg+xml">` |
| `src/components/Header.test.jsx` (novo) + `src/App.test.jsx` | 6 testes novos, 22 → 28 |

## Critério de saída do CP3

- **Favicon na aba** — verificar em produção depois do deploy.
- **Um único `<h1>` por rota** — ✅ o `<h1>Logo</h1>` do Header era placeholder desde o
  começo do projeto e dava **dois** `<h1>` em toda rota, porque cada página já tem o seu.

## Ordem dos commits: teste vermelho antes da implementação (princípio #2)

O commit de teste foi feito com a suíte **vermelha, 5 falhas**, e as duas contagens de `h1`
achavam 2 onde esperavam 1. É isso que prova que o teste testa alguma coisa.

## Decisões de desenho

- **Azul `#1D4ED8`** (`blue-700`): é o "mais claro que o azul da bandeira" (~`#002776`) que o
  cliente pediu, e casa com o gradiente `from-blue-800 to-cyan-500` já usado na Home e no Catálogo.
- **Duas variantes.** A ~56px do header o miolo da bandeira vira borrão, então a `reduzida`
  troca o mapa pela silhueta branca. A completa (arco-íris, sol e cruz) fica para o favicon e
  uso grande. Testei também manter o sol amarelo na reduzida — nesse tamanho ele some, não entrou.
- 🔴 **`textLength` é load-bearing** e está comentado no arquivo. É ele que faz as duas
  palavras terem a mesma largura, como na referência, **independente da fonte instalada na
  máquina do visitante**. Sem ele a logo se desmonta em quem não tem uma sans condensada.
- **Cores em atributos `fill`, não em utilitárias do Tailwind.** É exceção consciente à
  convenção do `CLAUDE.md`: o `public/favicon.svg` é arquivo estático onde o Tailwind não
  roda, e usar mecanismos diferentes nos dois lugares garantiria divergência. O Tailwind
  continua responsável pelo dimensionamento (`h-14 w-auto`).
- **Favicon só em SVG:** arquivo de texto versionável, nítido em qualquer tamanho, sem binário
  no repo. Cobre Chrome, Edge, Firefox e Safari 16+.
- **`useId()`** para o `id` do `clipPath` — sem isso, duas instâncias da logo na mesma página
  colidiriam.

## Fora do V1, de propósito

- O texto é `<text>` e não outline. Converter só se o cliente reclamar da forma das letras.
- **O contorno do mapa é aproximado.** Mapa exato é trabalho de designer, não de código — está
  registrado na seção 12.3 e precisa ser combinado com o cliente.

## Verificação

`npm run lint` exit 0 · **28/28 testes** · `npm run build` ok.

Navegador em `localhost:4180` (porta 4180 por causa do service worker que sequestra a 4173):
header, `/sobre`, `/rota-que-nao-existe` — **console limpo**.

Depois do merge, contra a produção: favicon na aba, `curl.exe -sSI .../favicon.svg` → 200 e
`image/svg+xml`, e confirmar que o hash do bundle mudou.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
