### PR TITLE
fix(sobre): devolve o fundo branco aos cards de missao, visao e valores

### DIFF
--- a/front-vassouras/src/pages/Sobre.jsx
+++ b/front-vassouras/src/pages/Sobre.jsx
@@ -24,7 +24,7 @@ function Sobre() {
       </div>
 
       <div className='CardsContainer grid grid-cols-1 md:grid-cols-3 gap-8 mt-10'>
-        <div className='relative bg-neutral-300 rounded-[35px] pt-[40px] px-[30px] pb-[30px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
+        <div className='relative bg-white rounded-[35px] pt-[40px] px-[30px] pb-[30px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
           <h2 className='text-3xl font-bold text-blue-500'>Missão</h2>
           <p className='text-zinc-600 font-bold leading-relaxed'>
             Nossa missão é fornecer vassouras de alta qualidade que atendam às
@@ -33,7 +33,7 @@ function Sobre() {
           </p>
         </div>
 
-        <div className='relative bg-neutral-300 rounded-[35px] pt-[40px] px-[30px] pb-[70px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
+        <div className='relative bg-white rounded-[35px] pt-[40px] px-[30px] pb-[70px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
           <h2 className='text-3xl font-bold text-blue-500'>Visão</h2>
           <p className='text-zinc-600 font-bold leading-relaxed'>
             Ser reconhecida como a principal fabricante de vassouras no mercado,
@@ -42,7 +42,7 @@ function Sobre() {
           </p>
         </div>
 
-        <div className='relative bg-neutral-300 rounded-[35px] pt-[40px] px-[30px] pb-[30px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
+        <div className='relative bg-white rounded-[35px] pt-[40px] px-[30px] pb-[30px] text-center flex flex-col items-center gap-[15px] shadow-[0_4px_12px_rgba(0,0,0,0.2)] transition-transform duration-300 hover:scale-105'>
           <h2 className='text-3xl font-bold text-blue-500'>Valores</h2>
           <ul className='text-left text-zinc-800 space-y-2'>
             <li className='font-bold text-zinc-600 leading-relaxed'>


### PR DESCRIPTION
Correção de um efeito colateral do CP2, reportado pelo dono do projeto ao ver a página.

## O que aconteceu

O PR #25 corrigiu a classe inválida `bg-color-neutral-300` trocando por `bg-neutral-300`.
A classe agora existe — e pinta um **cinza médio (`#d4d4d4`)**. Os três cards de
Missão/Visão/Valores ficaram cinza, que não era a aparência anterior.

## Por que `bg-white` e não remover a classe

A cor anterior dos cards era **branco**, não "nenhuma". Como `bg-color-neutral-300` não
existia, os cards ficavam transparentes sobre o fundo branco da página e só a sombra os
separava.

Remover a classe **não** devolveria isso hoje: o CP2 também corrigiu o typo `bg-gray-50"`
do `App.jsx`, então a página agora tem um cinza claro de verdade por baixo. Um card
transparente afundaria nesse cinza em vez de voltar ao que era. `bg-white` devolve
exatamente a cor que os cards tinham, e de quebra vira card branco sobre fundo `gray-50`,
que é o que a sombra já sugeria.

## Verificação

`npm run lint` exit 0 · **22/22 testes** · `npm run build` ok · conferido na tela em
`localhost:4180` (porta 4180 por causa do service worker que sequestra a 4173).

Independente do PR #26 (logo/favicon) — arquivos diferentes, sem conflito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
