### PR TITLE
fix(logo): aponta o head para SVG estatico e cria public/logo.svg

### DIFF
--- a/front-vassouras/index.html
+++ b/front-vassouras/index.html
@@ -1,13 +1,18 @@
 <!doctype html>
 <html lang="pt-BR">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg"/>
+    <meta property="og:title" content="Vassouras Pernambucanas"/>
+    <meta property="og:description"
+          content="Catalogo de vassouras, escovas e produtos de limpeza para revenda."/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:image" content="https://vass-pern-front.vercel.app/logo.svg"/>
     <title>Vassouras Pernambucanas</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+</head>
+<body>
+<div id="root"></div>
+<script type="module" src="/src/main.jsx"></script>
+</body>
 </html>

--- a/front-vassouras/public/logo.svg
+++ b/front-vassouras/public/logo.svg
@@ -1,8 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400" role="img" aria-label="Vassouras Pernambucanas">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 250" role="img" aria-label="Vassouras Pernambucanas">
   <title>Vassouras Pernambucanas</title>
-
-  <!-- E a marca da logo SEM as duas palavras, de proposito: a 16px da aba o
-       texto vira dois riscos ilegiveis. A logo completa vive em logo.svg. -->
 
   <defs>
     <clipPath id="recorte-pe">
@@ -10,9 +7,11 @@
     </clipPath>
   </defs>
 
-  <rect width="400" height="400" rx="64" fill="#2563EB"/>
+  <rect width="400" height="250" rx="18" fill="#2563EB"/>
 
-  <g transform="translate(6.5, 126.6) scale(0.2965)">
+  <text x="200" y="58" textLength="364" lengthAdjust="spacingAndGlyphs" text-anchor="middle" font-family="'Arial Narrow','Helvetica Neue',Helvetica,Arial,sans-serif" font-size="60" font-weight="700" fill="#FFFFFF">VASSOURAS</text>
+
+  <g transform="translate(28.7, 62.1) scale(0.2625)">
     <g clip-path="url(#recorte-pe)">
       <rect x="-20" y="-20" width="1350" height="305" fill="#3155A4"/>
       <rect x="-20" y="285" width="1350" height="230" fill="#FFFFFF"/>
@@ -27,4 +26,6 @@
     </g>
     <path d="M110,15 L140,25 L160,18 L200,30 L220,22 L255,22 L280,35 L305,38 L330,55 L360,65 L375,80 L400,95 L430,110 L455,128 L470,138 L490,120 L510,85 L525,90 L535,125 L550,130 L565,110 L580,115 L590,135 L610,140 L630,138 L660,140 L690,125 L710,110 L740,80 L770,55 L790,50 L810,55 L825,70 L840,80 L845,110 L835,135 L815,150 L810,170 L830,185 L850,200 L865,210 L870,230 L885,240 L905,230 L920,210 L940,190 L960,175 L985,165 L1010,160 L1030,165 L1050,170 L1070,165 L1090,150 L1110,155 L1125,140 L1140,150 L1155,135 L1170,110 L1190,95 L1210,85 L1230,90 L1250,105 L1265,120 L1280,135 L1295,160 L1300,190 L1290,220 L1270,250 L1255,280 L1240,310 L1230,340 L1220,370 L1210,390 L1190,405 L1170,410 L1150,415 L1130,418 L1110,410 L1095,400 L1080,390 L1060,385 L1040,395 L1020,405 L1000,410 L980,450 L960,475 L940,480 L910,478 L885,475 L860,470 L835,460 L815,445 L800,425 L785,410 L770,400 L755,390 L740,380 L725,385 L710,390 L700,380 L690,365 L680,360 L665,365 L650,380 L635,400 L620,430 L605,450 L595,460 L585,450 L580,425 L575,400 L565,385 L555,380 L545,390 L540,370 L535,355 L525,350 L515,360 L510,375 L500,365 L495,345 L485,340 L470,345 L455,340 L440,330 L425,325 L410,315 L390,310 L365,305 L340,300 L315,300 L295,305 L275,315 L260,330 L245,355 L235,380 L225,395 L210,390 L195,380 L180,385 L165,400 L155,425 L145,450 L135,470 L125,478 L110,470 L95,455 L85,440 L80,420 L75,400 L65,385 L50,375 L38,365 L35,350 L45,335 L60,325 L70,310 L65,290 L55,275 L40,260 L20,245 L5,230 L15,210 L30,190 L50,170 L65,150 L80,130 L90,105 L95,80 L100,50 Z" fill="none" stroke="#FFFFFF" stroke-width="14"/>
   </g>
+
+  <text x="200" y="234" textLength="364" lengthAdjust="spacingAndGlyphs" text-anchor="middle" font-family="'Arial Narrow','Helvetica Neue',Helvetica,Arial,sans-serif" font-size="48" font-weight="700" fill="#FFFFFF">PERNAMBUCANAS</text>
 </svg>


### PR DESCRIPTION
🔴 **O favicon do site está quebrado na `main` hoje.** O `href` do `<link rel="icon">` está
apontando para `/logo.jsx`.

## Por que não funciona — dois motivos independentes

1. **`/logo.jsx` não existe nesse caminho.** O componente é `src/components/Logo.jsx`, e só o
   que está em `public/` é servido na raiz do site.
2. **Mais fundamental: `<link rel="icon">` precisa de um arquivo de imagem estático.** Um
   `.jsx` é código-fonte JavaScript — quem o transforma em SVG é o React, dentro da página,
   depois que o bundle roda. O carregador de favicon do navegador **não executa JS**.

## O sintoma foi invisível do jeito mais chato possível

```
GET /logo.jsx  →  200 OK  ·  Content-Type: text/html
```

O **rewrite da SPA** devolve o `index.html` para qualquer rota desconhecida. O navegador
baixava HTML, tentava interpretar como imagem e descartava **em silêncio**. É o princípio #6
outra vez: 200 não prova nada aqui — só olhar o `Content-Type` denuncia.

## O que entra

| Arquivo | O quê |
| --- | --- |
| `public/logo.svg` (novo) | A logo completa como SVG estático. É o que torna a logo referenciável a partir do HTML |
| `public/favicon.svg` | Passa a ser a **marca da logo** (mapa + bandeira) em vez da bandeira retangular |
| `index.html` | `href` de volta para `/favicon.svg`, mais `og:title`, `og:description`, `og:type` e `og:image` |

**O favicon não leva as duas palavras, de propósito.** A 16 px da aba elas viram dois riscos
ilegíveis — conferido lado a lado a 64, 32 e 16 px antes de escolher.

**O `og:image` não é enfeite:** é o card de link do WhatsApp, e a conversão deste projeto é
por WhatsApp. O crawler não roda JS, mas lê meta estática do `index.html`, então **para a raiz
do site isso funciona de verdade** (o caso por produto continua precisando da rota no Django,
seção 8 do HANDOFF).

## ⚠️ Dívida que fica registrada

O `og:image` usa **URL absoluta de produção**, que é o que a especificação exige. **Quando o
domínio próprio entrar (CP9), este valor precisa mudar junto** — senão o card do WhatsApp
aponta para o domínio velho.

## Verificação

`npm run lint` exit 0 · **28/28 testes** · `npm run build` ok.

`/favicon.svg` e `/logo.svg` → **200 `image/svg+xml`**, e o `link[rel=icon]` do head resolve.

