### PR TITLE
feat(catalogo): catalogo em duas etapas por categoria (CP5 / pedido 12.1)

### DIFF
--- a/front-vassouras/src/App.jsx
+++ b/front-vassouras/src/App.jsx
@@ -1,6 +1,7 @@
 import './App.css';
 import Home from './pages/Home.jsx';
 import Catalogo from './pages/Catalogo.jsx';
+import Categorias from './pages/Categorias.jsx';
 import ProdutoDetalhe from './pages/ProdutoDetalhe.jsx';
 import Contatos from './pages/Contatos.jsx';
 import Sobre from './pages/Sobre.jsx';
@@ -17,7 +18,13 @@ function App() {
                 <main className='grow w-full  mx-auto'>
                     <Routes>
                         <Route path='/' element={<Home/>}/>
-                        <Route path='/produtos' element={<Catalogo/>}/>
+                        <Route path='/produtos' element={<Categorias/>}/>
+                        {/* Estatica antes da dinamica de proposito: com a rota
+                            propria, 'todos' nunca chega ao :categoriaId, e o
+                            Catalogo le "sem categoria" de um param undefined em
+                            vez de comparar com uma string magica. */}
+                        <Route path='/produtos/todos' element={<Catalogo/>}/>
+                        <Route path='/produtos/:categoriaId' element={<Catalogo/>}/>
                         <Route path='/produto/:id' element={<ProdutoDetalhe/>}/>
                         <Route path='/contatos/' element={<Contatos/>}/>
                         <Route path='/sobre/' element={<Sobre/>}/>

--- a/front-vassouras/src/App.test.jsx
+++ b/front-vassouras/src/App.test.jsx
@@ -55,4 +55,24 @@ describe('App', () => {
 
     expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
   });
+
+  it('deve ter um unico h1 na tela de categorias', async () => {
+    window.history.pushState({}, '', '/produtos');
+
+    render(<App />);
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+  });
+
+  it('deve ter um unico h1 nos produtos de uma categoria', async () => {
+    window.history.pushState({}, '', '/produtos/3');
+
+    render(<App />);
+
+    expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+  });
 });

--- a/front-vassouras/src/components/CategoriaCard.jsx
+++ b/front-vassouras/src/components/CategoriaCard.jsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom';
+import { Package } from 'lucide-react';
+
+const CategoriaCard = ({ categoria, prioritaria = false }) => (
+  <Link
+    to={`/produtos/${categoria.id}`}
+    className='group block w-full h-full min-w-0'
+  >
+    <div className='w-full h-full flex flex-col bg-white border rounded-lg shadow-sm hover:shadow-xl transition-shadow overflow-hidden'>
+      <div className='w-full aspect-[4/3] bg-blue-600 flex items-center justify-center overflow-hidden'>
+        {categoria.imagem ? (
+          <img
+            src={categoria.imagem}
+            alt={categoria.nome}
+            loading={prioritaria ? 'eager' : 'lazy'}
+            className='w-full h-full object-cover group-hover:scale-105 transition-transform duration-300'
+          />
+        ) : (
+          // O icone e decorativo: o nome da categoria ja esta em texto logo
+          // abaixo, e sem o aria-hidden ele entraria duas vezes no nome
+          // acessivel do link.
+          <Package
+            size={56}
+            strokeWidth={1.5}
+            className='text-white/80'
+            aria-hidden='true'
+          />
+        )}
+      </div>
+
+      <h2 className='p-4 text-base sm:text-lg font-bold text-gray-800 text-center'>
+        {categoria.nome}
+      </h2>
+    </div>
+  </Link>
+);
+
+export default CategoriaCard;

--- a/front-vassouras/src/components/ProdutosRow.jsx
+++ b/front-vassouras/src/components/ProdutosRow.jsx
@@ -83,7 +83,7 @@ const ProdutosRow = ({titulo, produtos}) => {
                 <h2 className='text-2xl font-bold text-yellow-500'>{titulo}</h2>
 
                 <Link
-                    to='/produtos'
+                    to='/produtos/todos'
                     className='bg-yellow-400 text-blue-900 font-bold text-sm py-2 px-5 rounded-xl shadow hover:bg-yellow-300 transition-transform hover:scale-105'
                 >
                     Ver todos →

--- a/front-vassouras/src/pages/Catalogo.jsx
+++ b/front-vassouras/src/pages/Catalogo.jsx
@@ -1,41 +1,84 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
 import ProdutoCard from '../components/ProdutoCard.jsx';
 import { API_BASE_URL, buscarJson } from '../services/api.js';
 
-function Catalogo() {
-  const [produtos, setProdutos] = useState([]);
-  const [categorias, setCategorias] = useState([]);
-  const [idCategoria, setIdCategoria] = useState(null);
-  const [termoBusca, setTermoBusca] = useState('');
+const MS_DEBOUNCE_BUSCA = 700;
 
+function Catalogo() {
+  // undefined na rota /produtos/todos, que o App.jsx registra separada da rota
+  // dinamica. E por isso que a string 'todos' nao aparece na logica daqui.
+  const { categoriaId } = useParams();
+
+  // O resultado carrega o id que o produziu para ser DERIVADO na rota atual.
+  // A alternativa era limpar o estado dentro do efeito ao trocar de categoria,
+  // que e o que ProdutoDetalhe faz e o que obrigou o eslint-disable de la.
+  const [resultadoCategoria, setResultadoCategoria] = useState(null);
+  // O `Boolean(resultadoCategoria) &&` nao e redundante: em /produtos/todos o
+  // categoriaId e undefined, e o optional chaining de um resultado nulo tambem
+  // da undefined — sem a guarda os dois batem e a rota sem categoria se declara
+  // dona de um resultado que nao existe.
+  const daRotaAtual =
+    Boolean(resultadoCategoria) && resultadoCategoria.id === categoriaId;
+  const categoria = daRotaAtual ? resultadoCategoria.dados : null;
+  const categoriaNaoEncontrada = daRotaAtual && resultadoCategoria.naoEncontrada;
+
+  const [produtos, setProdutos] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [erroCategorias, setErroCategorias] = useState(null);
+
+  const [termoBusca, setTermoBusca] = useState('');
+  const [termoBuscado, setTermoBuscado] = useState('');
+
+  // O debounce mora sozinho neste efeito, e nao no que busca os produtos: e o
+  // que faz a digitacao esperar 700ms e a troca de categoria nao esperar nada.
+  // Antes um unico timer cobria os dois, e clicar em categoria custava 700ms.
+  useEffect(() => {
+    const timerId = setTimeout(
+      () => setTermoBuscado(termoBusca),
+      MS_DEBOUNCE_BUSCA
+    );
+
+    return () => clearTimeout(timerId);
+  }, [termoBusca]);
 
   useEffect(() => {
+    if (!categoriaId) return;
+
     const controller = new AbortController();
     const signal = controller.signal;
 
-    async function fetchCategorias() {
-      setErroCategorias(null);
+    async function fetchCategoria() {
       try {
         const data = await buscarJson(
-          `${API_BASE_URL}/api/categorias/`,
+          `${API_BASE_URL}/api/categorias/${categoriaId}/`,
           signal
         );
-        if (!signal.aborted) setCategorias(data);
+        if (!signal.aborted) {
+          setResultadoCategoria({
+            id: categoriaId,
+            dados: data,
+            naoEncontrada: false,
+          });
+        }
       } catch (error) {
         if (error.name === 'AbortError') return;
         if (!signal.aborted) {
-          setErroCategorias('Não foi possível carregar as categorias.');
-          console.error('Erro ao processar categorias:', error);
+          // So o 404 daqui distingue categoria inexistente de categoria vazia:
+          // /api/produtos/?categoria=999 responde 200 com o catalogo inteiro.
+          setResultadoCategoria({
+            id: categoriaId,
+            dados: null,
+            naoEncontrada: error.status === 404,
+          });
+          console.error('Erro ao processar a categoria:', error);
         }
       }
     }
-    void fetchCategorias();
+    void fetchCategoria();
 
     return () => controller.abort();
-  }, []);
+  }, [categoriaId]);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -46,9 +89,8 @@ function Catalogo() {
       setError(null);
       try {
         const url = new URL(`${API_BASE_URL}/api/produtos/`);
-        if (idCategoria)
-          url.searchParams.append('categoria', String(idCategoria));
-        if (termoBusca) url.searchParams.append('search', termoBusca);
+        if (categoriaId) url.searchParams.append('categoria', categoriaId);
+        if (termoBuscado) url.searchParams.append('search', termoBuscado);
 
         const data = await buscarJson(url.toString(), signal);
 
@@ -56,102 +98,93 @@ function Catalogo() {
           setProdutos(data);
           setIsLoading(false);
         }
-      } catch (err) {
-        if (err.name === 'AbortError') return;
+      } catch (error) {
+        if (error.name === 'AbortError') return;
         if (!signal.aborted) {
           setError('Erro ao carregar produtos.');
           setIsLoading(false);
-          console.error('Erro ao processar produtos:', err);
+          console.error('Erro ao processar produtos:', error);
         }
       }
     }
-    const timerId = setTimeout(() => {
-      void fetchProdutos();
-    }, 700);
-    return () => {
-      clearTimeout(timerId);
-      controller.abort();
-    };
-  }, [idCategoria, termoBusca]);
+    void fetchProdutos();
+
+    return () => controller.abort();
+  }, [categoriaId, termoBuscado]);
+
+  if (categoriaNaoEncontrada) {
+    return (
+      <div className='p-10 text-center flex flex-col items-center gap-4'>
+        <h1 className='text-2xl font-bold text-gray-900'>
+          Categoria não encontrada
+        </h1>
+        <p className='text-gray-600'>
+          Esta categoria pode ter saído do catálogo.
+        </p>
+        <Link to='/produtos' className='text-blue-600 underline'>
+          Ver todas as categorias
+        </Link>
+      </div>
+    );
+  }
+
+  const titulo =
+    categoria?.nome ?? (categoriaId ? 'Produtos' : 'Todos os Produtos');
 
   return (
     <>
-      <div className='col-span-1 lg:col-span-4 bg-linear-to-br from-blue-800 to-cyan-500 mb-4 pb-4 text-center'>
+      <div className='bg-linear-to-br from-blue-800 to-cyan-500 mb-4 pb-4 text-center'>
         <h1 className='text-5xl md:text-4xl font-black text-white drop-shadow-md'>
-          Catálogo de <span className='text-yellow-400'>Produtos</span>
+          {titulo}
         </h1>
         <p className='text-lg md:text-xl text-white/90 mt-2 max-w-xl mx-auto leading-relaxed'>
           Encontre as melhores opções para o seu negócio.
         </p>
       </div>
-      <div className='CatalogoContainer p-4 grid grid-cols-1 lg:grid-cols-4 gap-8'>
-        <aside className='col-span-1 flex flex-col mb-8 overflow-x-auto pb-2 px-4   '>
-          <div className='InputContainer pb-6 border-b border-gray-200'>
-            <input
-              type='text'
-              placeholder='Buscar produtos...'
-              value={termoBusca}
-              onChange={(e) => setTermoBusca(e.target.value)}
-              className='mt-1 w-full bg-white text-gray-700 placeholder:text-gray-500 border border-gray-300 rounded-lg py-2 px-4 focus:outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500 transition-colors'
-            />
-          </div>
-          <button
-            onClick={() => setIdCategoria(null)}
-            className={`w-full text-left px-4 py-3 rounded-lg transition-colors border-l-4 cursor-pointer ${
-              idCategoria === null
-                ? 'bg-blue-50 text-blue-700 border-blue-600 font-bold'
-                : 'border-transparent text-gray-600 hover:bg-gray-100'
-            }`}
+
+      <div className='CatalogoContainer p-4 max-w-6xl mx-auto'>
+        <div className='flex flex-col sm:flex-row sm:items-center gap-4 mb-8'>
+          <Link
+            to='/produtos'
+            className='shrink-0 text-blue-600 hover:text-blue-800 underline'
           >
-            Todos
-          </button>
+            ← Todas as categorias
+          </Link>
 
-          {erroCategorias && (
-            <p className='px-4 py-3 text-sm text-red-500'>{erroCategorias}</p>
-          )}
+          <input
+            type='text'
+            placeholder='Buscar produtos...'
+            value={termoBusca}
+            onChange={(e) => setTermoBusca(e.target.value)}
+            className='w-full bg-white text-gray-700 placeholder:text-gray-500 border border-gray-300 rounded-lg py-2 px-4 focus:outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500 transition-colors'
+          />
+        </div>
 
-          {categorias.map((categoria) => (
-            <button
-              key={categoria.id}
-              onClick={() => setIdCategoria(categoria.id)}
-              className={`w-full text-left px-4 py-3 rounded-lg transition-colors border-l-4 cursor-pointer ${
-                idCategoria === categoria.id
-                  ? 'bg-blue-50 text-blue-700 border-blue-600 font-bold'
-                  : 'border-transparent text-gray-600 hover:bg-gray-100'
-              }`}
-            >
-              {categoria.nome}
-            </button>
-          ))}
-        </aside>
+        {isLoading && (
+          <div className='text-center text-blue-500 my-10 font-bold'>
+            Carregando produtos...
+          </div>
+        )}
 
-        <main className='col-span-1 lg:col-span-3'>
-          {isLoading && (
-            <div className='text-center text-blue-500 my-10 font-bold'>
-              Carregando produtos...
-            </div>
-          )}
+        {!isLoading && error && (
+          <div className='text-center text-red-500 my-10'>{error}</div>
+        )}
 
-          {!isLoading && error && (
-            <div className='text-center text-red-500 my-10'>{error}</div>
-          )}
+        {!isLoading && !error && produtos.length === 0 && (
+          <div className='text-center text-gray-500 my-10 font-bold'>
+            Nenhum produto encontrado.
+          </div>
+        )}
 
-          {!isLoading && !error && produtos.length === 0 && (
-            <div className='text-center text-gray-500 mt-10 font-bold'>
-              Nenhum produto encontrado.
-            </div>
-          )}
-
-          {!isLoading && !error && produtos.length > 0 && (
-            <ul className='w-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-6'>
-              {produtos.map((produto) => (
-                <li key={produto.id}>
-                  <ProdutoCard produto={produto} />
-                </li>
-              ))}
-            </ul>
-          )}
-        </main>
+        {!isLoading && !error && produtos.length > 0 && (
+          <ul className='w-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-6'>
+            {produtos.map((produto) => (
+              <li key={produto.id}>
+                <ProdutoCard produto={produto} />
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </>
   );

--- a/front-vassouras/src/pages/Catalogo.test.jsx
+++ b/front-vassouras/src/pages/Catalogo.test.jsx
@@ -1,11 +1,12 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import Catalogo from './Catalogo';
 
-const CATEGORIAS = [
-  { id: 2, nome: 'Escovas' },
-  { id: 3, nome: 'Vassouras' },
+const CATEGORIA = { id: 3, nome: 'Vassouras', descricao: '', imagem: null };
+
+const PRODUTOS = [
+  { id: 4, nome: 'Vassoura Nylon', preco: '20.00', imagem: null, categoria: 3 },
 ];
 
 const resposta = (corpo, status = 200) =>
@@ -15,73 +16,151 @@ const resposta = (corpo, status = 200) =>
     json: () => Promise.resolve(corpo),
   });
 
-function renderizar() {
+const urlsChamadas = () => fetch.mock.calls.map(([url]) => String(url));
+
+function renderizar(rota = '/produtos/3') {
   return render(
-    <MemoryRouter>
-      <Catalogo />
+    <MemoryRouter initialEntries={[rota]}>
+      <Routes>
+        <Route path='/produtos/todos' element={<Catalogo />} />
+        <Route path='/produtos/:categoriaId' element={<Catalogo />} />
+      </Routes>
     </MemoryRouter>
   );
 }
 
 describe('Catalogo', () => {
   beforeEach(() => {
-    vi.stubGlobal('fetch', vi.fn());
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url) =>
+        String(url).includes('/api/categorias/')
+          ? resposta(CATEGORIA)
+          : resposta(PRODUTOS)
+      )
+    );
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
 
-  it('deve listar as categorias quando a api responde', async () => {
+  it('deve buscar apenas os produtos da categoria da rota', async () => {
+    renderizar('/produtos/3');
+
+    expect(await screen.findByText('Vassoura Nylon')).toBeInTheDocument();
+    expect(
+      urlsChamadas().some((url) => url.includes('/api/produtos/?categoria=3'))
+    ).toBe(true);
+  });
+
+  it('deve exibir o nome da categoria no titulo da pagina', async () => {
+    renderizar('/produtos/3');
+
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /vassouras/i })
+    ).toBeInTheDocument();
+  });
+
+  // Categoria inexistente e categoria vazia sao coisas diferentes, e a tela
+  // precisa dizer qual das duas e. A API devolve 404 em /api/categorias/999/,
+  // mas 200 com o catalogo inteiro em /api/produtos/?categoria=999 — so o
+  // primeiro serve para decidir.
+  it('deve separar categoria inexistente de categoria sem produto', async () => {
     fetch.mockImplementation((url) =>
-      url.includes('/categorias/') ? resposta(CATEGORIAS) : resposta([])
+      String(url).includes('/api/categorias/')
+        ? resposta({ detail: 'nao encontrado' }, 404)
+        : resposta(PRODUTOS)
     );
 
-    renderizar();
+    renderizar('/produtos/999');
 
-    expect(await screen.findByText('Escovas')).toBeInTheDocument();
-    expect(screen.getByText('Vassouras')).toBeInTheDocument();
+    expect(
+      await screen.findByText(/categoria não encontrada/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Nenhum produto encontrado.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('deve buscar o catalogo inteiro na rota de todos os produtos', async () => {
+    renderizar('/produtos/todos');
+
+    expect(await screen.findByText('Vassoura Nylon')).toBeInTheDocument();
+
+    const urls = urlsChamadas();
+    expect(urls.some((url) => url.includes('/api/categorias/'))).toBe(false);
+    expect(urls.some((url) => url.includes('categoria='))).toBe(false);
+  });
+
+  // 🔴 Os dois testes abaixo sao o motivo do CP5 separar o debounce. Antes um
+  // unico timer de 700ms cobria categoria E texto, entao trocar de categoria
+  // custava 700ms a toa. Sem o segundo teste a separacao nao esta provada.
+  it('nao deve buscar antes da pausa na digitacao', async () => {
+    vi.useFakeTimers();
+
+    renderizar('/produtos/3');
+    fetch.mockClear();
+
+    fireEvent.change(screen.getByPlaceholderText(/buscar/i), {
+      target: { value: 'nylon' },
+    });
+
+    expect(fetch).not.toHaveBeenCalled();
+
+    await act(() => vi.advanceTimersByTimeAsync(700));
+
+    expect(urlsChamadas().some((url) => url.includes('search=nylon'))).toBe(
+      true
+    );
+  });
+
+  it('deve buscar os produtos da categoria sem esperar o debounce', () => {
+    vi.useFakeTimers();
+
+    renderizar('/produtos/3');
+
+    expect(
+      urlsChamadas().some((url) => url.includes('/api/produtos/?categoria=3'))
+    ).toBe(true);
   });
 
   // O catalogo mostrava "R$ 20.00" enquanto a PDP mostrava "R$ 20,00" para o mesmo produto.
   it('deve formatar o preco do card em pt-BR', async () => {
-    fetch.mockImplementation((url) =>
-      url.includes('/categorias/')
-        ? resposta([])
-        : resposta([{ id: 7, nome: 'Escova Oval', preco: '20.00', imagem: null }])
-    );
-
-    renderizar();
+    renderizar('/produtos/3');
 
     expect(await screen.findByText('R$ 20,00')).toBeInTheDocument();
   });
 
-  it('deve avisar quando a busca de categorias falha', async () => {
+  it('deve avisar quando a busca de produtos falha', async () => {
     fetch.mockImplementation((url) =>
-      url.includes('/categorias/') ? resposta(null, 500) : resposta([])
+      String(url).includes('/api/categorias/')
+        ? resposta(CATEGORIA)
+        : resposta(null, 500)
     );
 
-    renderizar();
+    renderizar('/produtos/3');
 
     expect(
-      await screen.findByText('Não foi possível carregar as categorias.')
+      await screen.findByText('Erro ao carregar produtos.')
     ).toBeInTheDocument();
   });
 
-  // O botao "Todos" e estatico. Sem esta assercao, a falha de categorias ficaria
-  // indistinguivel do estado normal — que era exatamente o defeito em producao.
-  it('nao deve confundir falha de categorias com catalogo sem categoria', async () => {
+  it('deve avisar quando a categoria nao tem produto', async () => {
     fetch.mockImplementation((url) =>
-      url.includes('/categorias/') ? resposta([]) : resposta([])
+      String(url).includes('/api/categorias/')
+        ? resposta(CATEGORIA)
+        : resposta([])
     );
 
-    renderizar();
+    renderizar('/produtos/3');
 
-    await waitFor(() => expect(fetch).toHaveBeenCalled());
-
-    expect(screen.getByText('Todos')).toBeInTheDocument();
     expect(
-      screen.queryByText('Não foi possível carregar as categorias.')
-    ).not.toBeInTheDocument();
+      await screen.findByText('Nenhum produto encontrado.')
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText(/categoria não encontrada/i)).not.toBeInTheDocument()
+    );
   });
 });

--- a/front-vassouras/src/pages/Categorias.jsx
+++ b/front-vassouras/src/pages/Categorias.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import CategoriaCard from '../components/CategoriaCard.jsx';
+import { API_BASE_URL, buscarJson } from '../services/api.js';
+
+// Estes cards sao a primeira dobra de /produtos, que e justamente a pagina onde
+// o passo 8 da secao 7 manda rerodar o Lighthouse. Dar lazy na candidata a LCP
+// piora exatamente a nota que se quer proteger, entao os de cima ficam eager.
+const CARDS_ACIMA_DA_DOBRA = 4;
+
+function Categorias() {
+  const [categorias, setCategorias] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    const signal = controller.signal;
+
+    async function fetchCategorias() {
+      try {
+        const data = await buscarJson(
+          `${API_BASE_URL}/api/categorias/`,
+          signal
+        );
+        if (!signal.aborted) {
+          setCategorias(data);
+          setIsLoading(false);
+        }
+      } catch (error) {
+        if (error.name === 'AbortError') return;
+        if (!signal.aborted) {
+          setError('Não foi possível carregar as categorias.');
+          setIsLoading(false);
+          console.error('Erro ao processar categorias:', error);
+        }
+      }
+    }
+    void fetchCategorias();
+
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <>
+      <div className='bg-linear-to-br from-blue-800 to-cyan-500 mb-4 pb-4 text-center'>
+        <h1 className='text-5xl md:text-4xl font-black text-white drop-shadow-md'>
+          Nossas <span className='text-yellow-400'>Categorias</span>
+        </h1>
+        <p className='text-lg md:text-xl text-white/90 mt-2 max-w-xl mx-auto leading-relaxed'>
+          Escolha uma categoria para ver os produtos.
+        </p>
+      </div>
+
+      <div className='CategoriasContainer p-4 max-w-6xl mx-auto'>
+        {isLoading && (
+          <div className='text-center text-blue-500 my-10 font-bold'>
+            Carregando categorias...
+          </div>
+        )}
+
+        {!isLoading && error && (
+          <div className='text-center text-red-500 my-10'>{error}</div>
+        )}
+
+        {!isLoading && !error && categorias.length === 0 && (
+          <div className='text-center text-gray-500 my-10 font-bold'>
+            Nenhuma categoria cadastrada.
+          </div>
+        )}
+
+        {!isLoading && !error && categorias.length > 0 && (
+          <ul className='w-full grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-6'>
+            {categorias.map((categoria, indice) => (
+              <li key={categoria.id}>
+                <CategoriaCard
+                  categoria={categoria}
+                  prioritaria={indice < CARDS_ACIMA_DA_DOBRA}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className='text-center my-10'>
+          <Link
+            to='/produtos/todos'
+            className='inline-block bg-yellow-400 text-blue-900 font-bold py-3 px-6 rounded-xl shadow hover:bg-yellow-300 transition-transform hover:scale-105'
+          >
+            Ver todos os produtos
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Categorias;

--- a/front-vassouras/src/pages/Categorias.test.jsx
+++ b/front-vassouras/src/pages/Categorias.test.jsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Categorias from './Categorias';
+
+const CATEGORIAS = [
+  { id: 2, nome: 'Escovas', descricao: '', imagem: 'https://exemplo/escovas' },
+  { id: 3, nome: 'Vassouras', descricao: '', imagem: null },
+];
+
+const resposta = (corpo, status = 200) =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(corpo),
+  });
+
+function renderizar() {
+  return render(
+    <MemoryRouter>
+      <Categorias />
+    </MemoryRouter>
+  );
+}
+
+describe('Categorias', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => resposta(CATEGORIAS)));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('deve dar a cada categoria um card que leva para a rota dela', async () => {
+    renderizar();
+
+    expect(
+      await screen.findByRole('link', { name: /escovas/i })
+    ).toHaveAttribute('href', '/produtos/2');
+    expect(screen.getByRole('link', { name: /vassouras/i })).toHaveAttribute(
+      'href',
+      '/produtos/3'
+    );
+  });
+
+  it('deve renderizar a foto da categoria que tem imagem', async () => {
+    renderizar();
+
+    expect(await screen.findByRole('img', { name: 'Escovas' })).toHaveAttribute(
+      'src',
+      'https://exemplo/escovas'
+    );
+  });
+
+  // Metade das categorias em producao esta sem foto, entao o fallback e o caminho
+  // normal e nao a excecao. O que ele nao pode virar e uma <img> apontando para
+  // null, que o navegador desenha como icone quebrado.
+  it('nao deve renderizar imagem na categoria sem foto', async () => {
+    renderizar();
+
+    await screen.findByRole('link', { name: /vassouras/i });
+
+    const imagens = screen.getAllByRole('img');
+    expect(imagens).toHaveLength(1);
+    expect(imagens[0]).toHaveAccessibleName('Escovas');
+  });
+
+  it('deve oferecer a saida para o catalogo inteiro', async () => {
+    renderizar();
+
+    await screen.findByRole('link', { name: /escovas/i });
+
+    expect(
+      screen.getByRole('link', { name: /ver todos os produtos/i })
+    ).toHaveAttribute('href', '/produtos/todos');
+  });
+
+  it('deve avisar quando a busca de categorias falha', async () => {
+    fetch.mockImplementation(() => resposta(null, 500));
+
+    renderizar();
+
+    expect(
+      await screen.findByText('Não foi possível carregar as categorias.')
+    ).toBeInTheDocument();
+  });
+
+  // Falha e lista vazia caiam na mesma tela no <aside> antigo, e isso ja foi
+  // defeito em producao (CP2). A tela nova nao pode reintroduzir.
+  it('nao deve confundir falha com catalogo sem categoria', async () => {
+    fetch.mockImplementation(() => resposta([]));
+
+    renderizar();
+
+    expect(
+      await screen.findByText('Nenhuma categoria cadastrada.')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Não foi possível carregar as categorias.')
+    ).not.toBeInTheDocument();
+  });
+});

--- a/front-vassouras/src/pages/ProdutoDetalhe.jsx
+++ b/front-vassouras/src/pages/ProdutoDetalhe.jsx
@@ -96,7 +96,7 @@ function ProdutoDetalhe() {
                         Tentar novamente
                     </button>
                 )}
-                <Link to='/produtos' className='text-blue-600 underline'>
+                <Link to='/produtos/todos' className='text-blue-600 underline'>
                     Ver todos os produtos
                 </Link>
             </div>
@@ -109,7 +109,12 @@ function ProdutoDetalhe() {
 
     return (
         <div className='ProdutoContainer bg-gray-100 rounded-lg max-w-6xl mx-auto p-6'>
-            <Link to='/produtos' className='inline-block mb-6'>
+            {/* Volta para a categoria de onde o visitante veio; /produtos agora
+                e a escolha de categoria, um passo atras do que ele fez. */}
+            <Link
+                to={produto.categoria ? `/produtos/${produto.categoria}` : '/produtos'}
+                className='inline-block mb-6'
+            >
                 <button className='bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded'>
                     Voltar
                 </button>

--- a/front-vassouras/src/pages/ProdutoDetalhe.test.jsx
+++ b/front-vassouras/src/pages/ProdutoDetalhe.test.jsx
@@ -27,6 +27,11 @@ function renderizar() {
       <Routes>
         <Route path='/produto/:id' element={<ProdutoDetalhe />} />
         <Route path='/produtos' element={<h2>Pagina do catalogo</h2>} />
+        <Route path='/produtos/todos' element={<h2>Todos os produtos</h2>} />
+        <Route
+          path='/produtos/:categoriaId'
+          element={<h2>Pagina da categoria</h2>}
+        />
       </Routes>
     </MemoryRouter>
   );
@@ -49,6 +54,36 @@ describe('ProdutoDetalhe', () => {
     renderizar();
 
     expect(await screen.findByText('Vassoura de Piaçava')).toBeInTheDocument();
+  });
+
+  // O produto ja traz a categoria dele, entao "Voltar" cai de onde o visitante
+  // veio. Com o catalogo em duas etapas, mandar para /produtos devolveria o
+  // visitante para a escolha de categoria — um passo atras do que ele fez.
+  it('deve voltar para a categoria do produto', async () => {
+    fetch.mockImplementation((url) =>
+      String(url).includes('?categoria=') ? resposta([]) : resposta(PRODUTO)
+    );
+
+    renderizar();
+
+    await screen.findByText('Vassoura de Piaçava');
+
+    expect(screen.getByRole('link', { name: /voltar/i })).toHaveAttribute(
+      'href',
+      '/produtos/2'
+    );
+  });
+
+  it('deve levar do erro para o catalogo inteiro', async () => {
+    fetch.mockImplementation(() => resposta({ detail: 'nao encontrado' }, 404));
+
+    renderizar();
+
+    await screen.findByText(/não encontrado/i);
+
+    expect(
+      screen.getByRole('link', { name: /ver todos os produtos/i })
+    ).toHaveAttribute('href', '/produtos/todos');
   });
 
   it('deve exibir nao encontrado quando a api responde 404', async () => {


### PR DESCRIPTION
Fecha o **pedido 12.1** do cliente no front (CP5). O par de back foi o #11 do `vass-pern-back`, ja mergeado e verificado em producao.

## O que muda para quem usa o site

| Rota | Antes | Depois |
| --- | --- | --- |
| `/produtos` | grid de produtos com `<aside>` de categorias | **grid de cards de categoria** |
| `/produtos/:categoriaId` | nao existia | produtos daquela categoria, com busca |
| `/produtos/todos` | nao existia | catalogo inteiro, com busca |

## As seis decisoes da secao 12.1

1. **Rota, nao estado local.** O trafego e pago: cada categoria vira landing page propria para o Ads, o botao voltar funciona e o link e compartilhavel no WhatsApp. Com estado local nada disso existe, e perder isso justamente na pagina de destino da campanha e caro.
2. **Card sem foto** cai num bloco azul da marca com icone do `lucide-react` (ja era dependencia). Nao e caminho de excecao: **metade das categorias em producao esta sem imagem** hoje, entao e o que o cliente ve.
3. **A busca nao atravessa a etapa.** `/produtos` e chooser puro; a caixa de busca vive na tela de produtos e filtra dentro da categoria aberta.
4. **Debounce separado.** Antes um unico timer de 700ms cobria categoria E texto — clicar em categoria custava 700ms a toa. Agora o timer vive num efeito so dele.
5. **Saida "Ver todos os produtos"** → `/produtos/todos`. `ProdutosRow` e o link de erro da PDP apontam para la, porque o rotulo promete o catalogo inteiro.
6. **LCP:** os 4 primeiros cards ficam `eager`, o resto `lazy`. O grid e a primeira dobra da pagina onde o passo 8 manda rerodar o Lighthouse.

## Duas coisas que valem leitura com atencao

**A rota `/produtos/todos` e registrada separada da dinamica.** Assim a string `'todos'` nunca chega ao componente e "sem categoria" e simplesmente `useParams().categoriaId === undefined` — sem string magica no meio da logica.

**Categoria inexistente e categoria vazia sao coisas diferentes, e so o 404 de `/api/categorias/<id>/` decide.** `/api/produtos/?categoria=999` responde **200 com o catalogo inteiro** (verificado em producao), entao usar o endpoint de produtos para isso mostraria o catalogo todo sob o titulo de uma categoria que nao existe.

**O estado da categoria e derivado, nao resetado.** `resultadoCategoria` guarda o id que o produziu, e o componente compara com o da rota. A alternativa era limpar o estado dentro do efeito ao trocar de categoria — que e o que `ProdutoDetalhe` faz e o que obrigou o `eslint-disable` de la.

Uma armadilha que o teste pegou e que vale registrar: em `/produtos/todos` o `categoriaId` e `undefined` **e** `resultadoCategoria?.id` tambem e `undefined`. Os dois batem, e sem uma guarda explicita a rota sem categoria se declarava dona de um resultado que nao existe. Esta comentado no codigo para ninguem "simplificar" de volta.

## Verificacao

Teste vermelho antes da implementacao (principio #2): o commit `8c78f61` deixa **12 falhas** registradas — `Categorias.test.jsx` sem a pagina que importa, `Catalogo.test.jsx` 9 de 9 no `<aside>` que sai, e a navegacao da PDP.

- `npm run lint` → exit 0
- `npx vitest --run` → **43 verdes** (era 28)
- `npm run build` → ok

No navegador, contra os **dados reais da Railway** (servidos por um proxy local, porque producao so libera CORS para os dominios da Vercel e afrouxar isso seria pior que o bug):

- `/produtos` mostra os dois cards — Escovas com a foto do Cloudinary, Vassouras com o fallback azul;
- **F5 em `/produtos/3`** volta com o `h1` "Vassouras" e os produtos — e o criterio de saida do CP5;
- botao voltar do navegador retorna para `/produtos`;
- `/produtos/999` → "Categoria nao encontrada", sem tela branca;
- "Voltar" da PDP cai em `/produtos/3`, a categoria do produto;
- digitar `sanitaria` (9 teclas) gera **uma unica** requisicao, `?search=sanitaria` — o debounce medido na aba Network, nao so sob fake timers;
- console limpo: o unico erro do bundle novo foi o 404 que provoquei de proposito.

## Fora deste PR

`Home`, `Header`, `Footer` e `NaoEncontrada` continuam apontando para `/produtos`: nos quatro o rotulo e "Produtos"/"catalogo", e a nova porta de entrada do catalogo e justamente o grid de categorias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)